### PR TITLE
Add initial main landing page

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,6 @@
+# Northstar
+
+Here you can find all the documentation for the Titanfall2 mod [Northstar](https://northstar.tf)
+
+- For using Northstar, [check our wiki](https://r2northstar.gitbook.io/)
+- For modding with Northstar, check the [modding docs](Modding/index.md)


### PR DESCRIPTION
That's the page that will be shown when going to https://docs.northstar.tf/

This version is pretty bare bones and just so that we have something there instead of a 404. Improvements are more than welcome.
