### PR TITLE
Use correct syntax identifier for some code blocks

### DIFF
--- a/docs/Modding/reference/northstar/customdamagesources.md
+++ b/docs/Modding/reference/northstar/customdamagesources.md
@@ -18,7 +18,7 @@ Damage source IDs should be added in ``"After"`` server callbacks.
 
 For example, we can call the methods from a function in ``damage_source_example.nut``:
 
-```csharp
+```squirrel
 
     global function SimpleSourceInit
 
@@ -58,7 +58,7 @@ Then call the function as an ``"After"`` server callback in the ``mod.json``:
 
 Now, these damage source IDs can be referenced in script like so:
 
-```csharp
+```squirrel
 
     eDamageSourceId.mp_weapon_minigun
     eDamageSourceId.mp_titanweapon_barrage_core_launcher


### PR DESCRIPTION
`squirrel` instead of `csharp`