### PR TITLE
Convert leftover reStructuredText syntax to Markdown

### DIFF
--- a/docs/Modding/reference/respawn/hud_element_notation.md
+++ b/docs/Modding/reference/respawn/hud_element_notation.md
@@ -432,11 +432,12 @@ Usable conditions are:
 
     the game's language.
 
-    .. code-block:: text
+    ```text
 
             // use allcaps only in russian
             allCaps        0  [!$RUSSIAN]
             allCaps        1  [$RUSSIAN]
+    ```
 
 
 
@@ -531,11 +532,12 @@ You can calculate the position or dimensions etc. with different units. If you p
 
     x percent of the screen.
 
-    .. code:block::
+    ```
 
         // cover the entire screen
         width   %100
         height  %100
+    ```
 
 !!! cpp-function "fx"
 

--- a/docs/Modding/reference/respawn/native_server/damageinfo.md
+++ b/docs/Modding/reference/respawn/native_server/damageinfo.md
@@ -144,19 +144,19 @@ Because damageInfo instances are implemented as userdata they can't be typed.
 
 !!! cpp-function "bool HeavyArmorCriticalHitRequired( var damageInfo )"
 
-  .. note::
+  !!! note
 
     SERVER only
 
 !!! cpp-function "bool CritWeaponInDamageInfo( var damageInfo )"
 
-  .. note::
+  !!! note
 
     SERVER only
 
 !!! cpp-function "float GetCriticalScaler( ent, damageInfo )"
 
-  .. note::
+  !!! note
 
     SERVER only
 


### PR DESCRIPTION
There were some leftover snippets that were overlooked in #2
