### PR TITLE
Remove superfluous newline at the start of codeblocks

### DIFF
--- a/docs/Modding/guides/contributing.md
+++ b/docs/Modding/guides/contributing.md
@@ -31,7 +31,6 @@ You need to have a relatively recent version of Python installed - 3.8 or higher
 === "Windows"
 
     ```powershell
-
     git clone https://github.com/R2Northstar/ModdingDocs/
     cd ModdingDocs
     ./run.ps1
@@ -40,7 +39,6 @@ You need to have a relatively recent version of Python installed - 3.8 or higher
 === "Linux"
 
     ```bash
-
     git clone https://github.com/R2Northstar/ModdingDocs/
     cd ModdingDocs
     ./run.sh

--- a/docs/Modding/guides/gettingstarted.md
+++ b/docs/Modding/guides/gettingstarted.md
@@ -31,7 +31,6 @@ Provided is a template `mod.json`, for a detailed list of values read the
 `cheatsheet`
 
 ```json
-
     {
        "Name": "Yourname.Modname",
        "Description": "Woo yeah wooo!",
@@ -49,7 +48,6 @@ be overwritten and new files can be added. If you need to define new Squirrel fi
 example for this might be:
 
 ```json
-
     "Scripts": [
        {
           "Path": "path/to/file.nut",
@@ -87,7 +85,6 @@ This guide will dig into each of the possible `mod.json` fields. Please note tha
 This is what a well-formatted `mod.json` looks like:
 
 ```json
-
     {
         "Name": "Northstar.CustomServers",
         "Description": "Attempts to recreate the behaviour of vanilla Titanfall 2 servers, as well as changing some scripts to allow better support for mods",
@@ -174,7 +171,6 @@ If I don't want to wait 15 seconds for matches to start on my server,
 `ns_private_match_countdown_length` in its `mod.json` manifesto:
 
 ```json
-
     "ConVars": [
         {
             "Name": "ns_private_match_countdown_length",
@@ -193,7 +189,6 @@ When starting a match, `Northstar.CustomServers` mod will retrieve the configura
 variable value, or its default value if it hasn't been specified in configuration file:
 
 ```squirrel
-
     // start countdown
     SetUIVar( level, "gameStartTime", Time() + GetConVarFloat( "ns_private_match_countdown_length" ) )
 ```
@@ -252,7 +247,6 @@ The scripts field lets you declare an array of Squirrel files to import into you
 Each script entry must have a "Path" value and a "RunOn" value.
 
 ```json
-
      "Scripts": [
          {
              "Path": "path/to/file.nut",

--- a/docs/Modding/guides/keyvalue/crosshairmodding.md
+++ b/docs/Modding/guides/keyvalue/crosshairmodding.md
@@ -11,7 +11,6 @@ Example Mod:
 2: Put the following into the newly created .txt file:
 
 ```
-
    WeaponData
    {
        RUI_CrosshairData
@@ -35,7 +34,6 @@ Weapons].txt
 into one**
 
 ```
-
    WeaponData
    {
        active_crosshair_count              "2" //Amount of crosshairs you want to use
@@ -71,7 +69,6 @@ Simply add the following line below the  "ui" line
 Below the "ui" line, Like this:
 
 ```
-
     {
        RUI_CrosshairData
        {
@@ -89,7 +86,6 @@ Below the "ui" line, Like this:
 ## No Crosshair?
 
 ```
-
    WeaponData
    {
        RUI_CrosshairData

--- a/docs/Modding/guides/keyvalue/localisation.md
+++ b/docs/Modding/guides/keyvalue/localisation.md
@@ -23,7 +23,6 @@ Languages natively supported by Titanfall2 are:
 Here's what a translation file looks like:
 
 ```json
-
     "lang"
     {
         "Language" "english"
@@ -59,7 +58,6 @@ For example, Northstar translation files are named
 You can import them from your `mod.json` manifesto this way:
 
 ```json
-
     {
         "Localisation": [
             "resource/northstar_client_localisation_%language%.txt"
@@ -82,21 +80,18 @@ For example, to translate the "Launch Northstar" button on main menu, instead of
 calling:
 
 ```
-
     AddComboButton( comboStruct, headerIndex, buttonIndex++, "Launch Northstar" )
 ```
 
 We'll use:
 
 ```
-
     AddComboButton( comboStruct, headerIndex, buttonIndex++, "#MENU_LAUNCH_NORTHSTAR" )
 ```
 
 You can also use the `Localize` method client-side:
 
 ```
-
     Localize( "#MENU_LAUNCH_NORTHSTAR" )
 ```
 

--- a/docs/Modding/guides/publishing.md
+++ b/docs/Modding/guides/publishing.md
@@ -12,7 +12,6 @@ If the changes your mod makes can be represented in screenshots, gameplay record
 To do so, simply upload the image or gif to a host of your choice (Imgur, GitHub, and even Discord all work). To display the image directly on your page in Thunderstore, add the following line to your README:
 
 ```markdown
-
     ![alt text, this text shows up when image cannot be loaded](https://example.com/image/to/link/to.gif)
 ```
 
@@ -26,7 +25,6 @@ The best place to publish your mod is [Thunderstore](https://northstar.thunderst
 The Thunderstore package zip structure is as follows:
 
 ```
-
     mods/<your name>.<mod name>/
     icon.png
     manifest.json

--- a/docs/Modding/guides/reversing/squirrelreversing.md
+++ b/docs/Modding/guides/reversing/squirrelreversing.md
@@ -39,7 +39,6 @@ You can search for a string in memory with `Search > Memory`. Select `String` as
 The first occurence is at `server.dll+0x2b44f3`. If you wait for the function to be decompiled, you'll see the string in this code:
 
 ```c
-
     _DAT_181055f60 = "IsServer";
     _DAT_181055f68 = "IsServer";
     _DAT_181055fb8 = 0;
@@ -56,7 +55,6 @@ The first occurence is at `server.dll+0x2b44f3`. If you wait for the function to
 Because the squirrel function executes native code, the callback `FUN_18029a630` is probably where it's located. You can double click the reference to decompile the function.
 
 ```c
-
     undefined4 FUN_18029a630(undefined8 param_1)
     {
         char cVar1;
@@ -76,7 +74,6 @@ From this you can assume that native closures in squirrel_re still use the `SQRE
 It's also obvious that either `FUN_180003710` or `FUN_18001d840` pushes a boolean to the stack. It's probably `FUN_180003710` because it takes an extra parameter but you can check `IsClient` at `server.dll+0x29a4d0` as a reference.
 
 ```c
-
     undefined4 FUN_18029a4d0(undefined8 param_1)
     {
         char cVar1;
@@ -98,7 +95,6 @@ Decompile the function, then right click the function and select `Edit Function 
 Right now the signature looks like this:
 
 ```c
-
     void FUN_180003710(longlong param_1, int param_2)
 ```
 
@@ -109,6 +105,5 @@ The second parameter has to be the value that will be pushed to the VM as a bool
 You can change the signature now to this, to make code using the function more readable. Because `HSquirrelVM` isn't defined yet, the type needs to stay `longlong` for now.
 
 ```c
-
     void sq_pushbool(longlong sqvm, int value)
 ```

--- a/docs/Modding/guides/scripting/custommenus.md
+++ b/docs/Modding/guides/scripting/custommenus.md
@@ -7,7 +7,6 @@ This tutorial will explain how to create a mod that adds a new menu that's viewa
 First, create a new folder with this `mod.json`:
 
 ```json
-
     {
         "Name": "CustomMenuTutorial",
         "Description": "Custom menu tutorial",
@@ -31,7 +30,6 @@ Then create `custom_menu.nut` in `./mod/scripts/vscripts/ui`.
 Create `AddCustomMenu` in `custom_menu.nut` like this and make it global:
 
 ```squirrel
-
     global function AddCustomMenu
 
     void function AddCustomMenu()
@@ -47,7 +45,6 @@ Next, create the file that defines the layout of your menu. It's already referen
 ??? ".menu configuration"
 
     ```
-
         resource/ui/menus/custommenu.menu
         {
             menu
@@ -130,7 +127,6 @@ Now you'll need to define `CustomMenu_Init`. This is the function previously def
 First, create an instantiated struct for variables that should be available in the scope of your custom menu script.
 
 ```squirrel
-
     struct {
         var menu
     } file
@@ -139,7 +135,6 @@ First, create an instantiated struct for variables that should be available in t
 At the moment, this struct can only contain your menu. To set it, edit `AddCustomMenu` like this:
 
 ```diff
-
      void function AddCustomMenu()
      {
         AddMenu( "CustomMenu", $"resource/ui/menus/custommenu.menu", CustomMenu_Init )
@@ -150,7 +145,6 @@ At the moment, this struct can only contain your menu. To set it, edit `AddCusto
 Now, define `CustomMenu_Init`. It doesn't need to be global.
 
 ```squirrel
-
     void function CustomMenu_Init()
     {
         AddMenuFooterOption( file.menu, BUTTON_B, "#B_BUTTON_BACK", "#BACK" )
@@ -164,14 +158,12 @@ This adds a footer to your menu, that allows the user to navigate back.
 Currently, there is no way to access your menu. You can open your (or any other menu) with `AdvanceMenu`.
 
 ```squirrel
-
     AdvanceMenu( GetMenu( "CustomMenu" ) )
 ```
 
 This is useful for callbacks triggered by button presses like from footers. To add a footer to the Main menu, first edit your `mod.json` code callbacks:
 
 ```diff
-
      "Scripts": [
         {
             "Path": "ui/custom_menu.nut",
@@ -187,7 +179,6 @@ This is useful for callbacks triggered by button presses like from footers. To a
 We need a new callback that's run after all menus are initialized to add any footers to them. Create the global function `AddCustomMenuFooter` in `custom_menu.nut` like this:
 
 ```squirrel
-
     void function AddCustomMenuFooter()
     {
         AddMenuFooterOption(
@@ -216,7 +207,6 @@ We'll use the button we defined earlier in the `.menu` file to increase a number
 first, add `someLabel` and `clicks` to the `file` struct. Then define the label in the `AddCustomMenu` and add a callback to the button.
 
 ```diff
-
      struct {
         var menu
 +           var someLabel
@@ -237,7 +227,6 @@ first, add `someLabel` and `clicks` to the `file` struct. Then define the label 
 Now you need to define the `OnSomeButtonClick` callback that's triggered when the button is activated.
 
 ```squirrel
-
     void function OnSomeButtonClick( var button )
     {
         file.clicks++
@@ -250,7 +239,6 @@ Now you need to define the `OnSomeButtonClick` callback that's triggered when th
 First you need to add a definition in your `custommenu.menu` file:
 
 ```
-
     ResetButton
     {
         ControlName RuiButton
@@ -271,7 +259,6 @@ First you need to add a definition in your `custommenu.menu` file:
 Then add a `UIE_CLICK` callback for the button. It also makes sense to move the code that updates the label text to it's own function so it can be reused by the reset button.
 
 ```diff
-
      void function AddCustomMenu()
      {
         AddMenu( "CustomMenu", $"resource/ui/menus/custommenu.menu", CustomMenu_Init )
@@ -311,7 +298,6 @@ You can add callbacks for menu events, for example when a menu is closed or open
 If you want to reset the counter if the menu is closed, edit `AddCustomMenu` like this:
 
 ```diff
-
      void function AddCustomMenu()
      {
         AddMenu( "CustomMenu", $"resource/ui/menus/custommenu.menu", CustomMenu_Init )
@@ -331,7 +317,6 @@ If you want to reset the counter if the menu is closed, edit `AddCustomMenu` lik
 And define the callback `OnCloseCustomMenu` to simply call `OnResetButtonClick`.
 
 ```squirrel
-
     void function OnCloseCustomMenu()
     {
         OnResetButtonClick( null )

--- a/docs/Modding/guides/scripting/gamemodemods.md
+++ b/docs/Modding/guides/scripting/gamemodemods.md
@@ -10,7 +10,6 @@ The `mod.json` is responsible for governing when, and where your mod is loaded, 
 However, once you get the hang of it, it should be fairly easy to use.
 
 ```json
-
     {
         "Name" : "SimpleRandomiser",
         "Description" : "A randomiser gamemode that randomizes your loadouts!",
@@ -21,7 +20,6 @@ However, once you get the hang of it, it should be fairly easy to use.
 The script above defines the pubic and listed details of the mod.
 
 ```json
-
     "Scripts": [
         {
             "Path": "gamemodes/_gamemode_simplerandomiser.nut",
@@ -57,7 +55,6 @@ For example, both server and client needs to know whether if this gamemode exist
 
 
 ```json
-
         "Localisation": [
             "resource/simplerandomiser_localisation_%language%.txt"
         ]
@@ -71,7 +68,6 @@ Name this file `mod.json`, and it should go in the mods root folder, that being 
 Here's what the end result would look like:
 
 ```json
-
     {
         "Name" : "SimpleRandomiser",
         "Description" : "SimpleRandomiser",
@@ -127,7 +123,6 @@ Name this file `simplerandomiser_localisation_english.txt` and place it in the `
 Let's begin the process by first creating the file `sh_gamemode_simplerandomiser.nut` and making the core components of the gamemode, which is to define the gamemode properties.
 
 ```squirrel
-
     global function simplerandomiser_init // initializing functions
     global const string GAMEMODE_SIMPLERANDOMISER = "rand"
     // we want a short term to use which allows server owners to
@@ -202,7 +197,6 @@ Now that we're done, name this file `sh_gamemode_simplerandomiser.nut` and place
 Now that we're down with defining the gamemode, its time to focus on the component on that makes the gamemode function in-game. For this, it will be mostly handled by the server scripts, so head into `_gamemode_simplerandomiser.nut` to begin writing the randomizing script.
 
 ```squirrel
-
     global function GamemodeRand_Init
 
     void function GamemodeRand_Init()
@@ -223,7 +217,6 @@ Firstly, we need to know what weapons we can equip.
 For this we define an array:
 
 ```squirrel
-
     array<string> pilotWeapons = ["mp_weapon_alternator_smg",
                                   "mp_weapon_autopistol",
                                   "mp_weapon_car",
@@ -238,7 +231,6 @@ As we already know its going to call the function `GiveRandomGun` when a player 
 First we strip any existing weapons:
 
 ```squirrel
-
     void function GiveRandomGun(entity player)
     {
         foreach ( entity weapon in player.GetMainWeapons() )
@@ -250,7 +242,6 @@ This iterates through each weapon (that being the primary, secondary and anti-ti
 Then lets give them a new, random weapon by selecting a random item from our previous array:
 
 ```squirrel
-
     player.GiveWeapon( pilotWeapons[ RandomInt( pilotWeapons.len() ) ] )
 ```
 
@@ -258,7 +249,6 @@ Now, remember the server callback that we defined earlier in `sh_gamemode_simple
 We are going to make it so the player receives an announcement whenever they have their weapons randomized.
 
 ```squirrel
-
     // checks if the toggle option is set to enabled
     if ( GetCurrentPlaylistVarInt( "rand_enableannouncements", 1 ) == 1 )
         Remote_CallFunction_NonReplay( player, "ServerCallback_Randomiser" ) // call the function that will be used client-side
@@ -267,7 +257,6 @@ We are going to make it so the player receives an announcement whenever they hav
 Overall, the server script should look like this.
 
 ```squirrel
-
     global function GamemodeRand_Init
 
     void function GamemodeRand_Init()
@@ -304,7 +293,6 @@ Make sure to double check that all spellings are correct in your mod as everythi
 Lastly, for your `cl_gamemode_simplerandomiser.nut`, we are going to utilize the callback functions from earlier, as well as add some music to play during the gamemode.
 
 ```squirrel
-
     global function ClGamemodeRand_Init
     global function ServerCallback_Randomiser
 
@@ -356,7 +344,6 @@ Technically, yes, you could. But it wouldn't look pretty. Remember all those str
 Hence, open your `simplerandomiser_localisation_english.txt` which is located in the `yourmodsname/mod/resource/` folder.
 
 ```json
-
     "lang"
     {
     "Language" "english"
@@ -387,7 +374,6 @@ Yes, you will need to create a folder called `keyvalues` which is separate from 
 Next, inside this `playlists_v2.txt`, we will need to allow/disallow what maps can the gamemode be played on.
 
 ```text
-
     playlists
     {
     Gamemodes

--- a/docs/Modding/guides/tools/BIKVideoModding.md
+++ b/docs/Modding/guides/tools/BIKVideoModding.md
@@ -27,7 +27,6 @@ The Video will now be in the same folder as the original one and converted to a 
 3. Make a mod according to [Getting Started](../gettingstarted.md)
 4. Copy the .bik to the following path in your mod folder:
     ```text
-
         author.mod/
         ├─ mod.json
         ├─ media/

--- a/docs/Modding/guides/tools/MDLModding.md
+++ b/docs/Modding/guides/tools/MDLModding.md
@@ -105,7 +105,6 @@ We will add a cube to the side of the Flatline and assign a custom material to i
 - You will now see a list of all files in the `.vpk` file on the left side looking something like this:
 
 ``` text
-
     RootDir
     ├── materials
     ├── resource
@@ -266,14 +265,12 @@ If you have materials with multiple paths (different folders in the game files) 
 Usage:
 
 ```text
-
         $renamematerial <current material> <new material>
 ```
 
 Example:
 
 ```text
-
         $renamematerial "models\weapons_r2\coolmaterial\cool_material" "models\amazing\uncoolmaterial\cool_material2"
 ```
 
@@ -297,7 +294,6 @@ Command docs: [VALVe developer docs $renamematerial](https://developer.valvesoft
 - Open your `.qc` file in a text editor of your choice.
 - On the top of the file you will see so called "bodygroup" lines, these are used to define the bodygroups of the model. They look a bit like this:
     ```
-
             $bodygroup "body"
             {
                 studio "ptpov_vinson_v_vinson.smd"

--- a/docs/Modding/guides/tools/VTFModding.md
+++ b/docs/Modding/guides/tools/VTFModding.md
@@ -63,7 +63,6 @@ In the same folder you extracted your mdl's. Make a `materials` folder next to t
 
 Example:
 ```
-
     models
     materials
 ```
@@ -71,7 +70,6 @@ Example:
 Recreate the path you changed in the `materials` folder, such that the last section is a .vmt file:
 
 ```text
-
     materials
     └─ models
           └─ weapons_r2
@@ -83,7 +81,6 @@ Recreate the path you changed in the `materials` folder, such that the last sect
 Inside your .vmt paste:
 
 ```
-
     "UnlitTwoTexture"
     {
 
@@ -130,7 +127,6 @@ In some cases you might have to create another vtf with literally any image. Put
 Your root folder should look somewhat like this
 
 ```text
-
     root
     ├─ materials
     │  └─ models
@@ -162,7 +158,6 @@ You need to create a .vtf texture with multiple frames imported to a single .vtf
 At the bottom of your vmt but before the `}`, add this:
 
 ```text
-
     "Proxies"
     {
             AnimatedTexture

--- a/docs/Modding/guides/tools/rpakmodding.md
+++ b/docs/Modding/guides/tools/rpakmodding.md
@@ -30,7 +30,6 @@ Once it has been downloaded, it is recommended to set up your file structure as 
     Depending on the version of RePak, some of these folders and files might be already there for you
 
 ```text
-
     RePak
     ├── RePak.exe
     ├── pack_all.bat
@@ -52,7 +51,6 @@ Once it has been downloaded, it is recommended to set up your file structure as 
 Below is the script that should be copied into the file.
 
 ```bat
-
     for %%i in ("%~dp0maps\*") do "%~dp0RePak.exe" "%%i"
     pause
 ```
@@ -123,7 +121,6 @@ They can be named anything you want, but should be put in the `RePak\maps` folde
 Below is an example of a map file that creates an RPak called `example.rpak` which contains 1 texture asset.
 
 ```json
-
     {
         "name":"example",
         "assetsDir":"../assets",
@@ -179,7 +176,6 @@ In this example, the `camo_skin04_col.rpak` rpak is completely replaced by `exam
 This is fine for camo RPaks, but isn't suitable for more complex RPaks
 
 ```json
-
     {
         "Preload":
         {
@@ -233,7 +229,6 @@ The file structure of your `paks` folder should be similar to this:
 ![PaksStructure](https://user-images.githubusercontent.com/66967891/181840126-98e48860-84d0-496d-8f2e-1cea4dea7363.png)
 
 ```text
-
     paks
     ├── example.rpak
     ├── example.starpak

--- a/docs/Modding/guides/tools/soundmodding.md
+++ b/docs/Modding/guides/tools/soundmodding.md
@@ -50,7 +50,6 @@ ready it's time to set up the folder structure.
 Assuming the event name is `pilot_grapple_fire`, the folder structure of your mod should look like this:
 
 ```text
-
    author.mod/
    ├── audio/
    │   ├── pilot_grapple_fire/
@@ -64,7 +63,6 @@ Example of a `mod.json` (documented here: [Getting Started](../gettingstarted.md
 
 
 ```json
-
    {
      "Name": "MOD_NAME_HERE",
      "Description": "DESCRIPTION_HERE",
@@ -84,7 +82,6 @@ The event JSON files must contain both `EventId` and `AudioSelectionStrategy` li
 
 
 ```json
-
    {
        "EventId": [ "pilot_grapple_fire" ],
        "AudioSelectionStrategy": "sequential"
@@ -160,7 +157,6 @@ This is usually because there's some metadata left in the audio. Remove it to fi
     === "WAV script"
 
         ```shell
-
                #WAV to WAV 16-bit 48000 Hz.
                #wav_converter.sh
 
@@ -176,7 +172,6 @@ This is usually because there's some metadata left in the audio. Remove it to fi
     === "MP3 Script"
 
         ```shell
-
                #MP3 to WAV 16-bit 48000 Hz.
                #mp3-wav_converter.sh
 

--- a/docs/Modding/plugins/interfacesapi.md
+++ b/docs/Modding/plugins/interfacesapi.md
@@ -18,7 +18,6 @@ An interface is just an abstract class to force all functions into a vftable.
 Exposes some system functionality to plugins
 
 ```cpp
-
     // 32 bit
     enum LogLevel {
       INFO,
@@ -39,7 +38,6 @@ Interfaces that have to be exposed for the plugin to be loaded.
 ### PluginId001
 
 ```cpp
-
     // strings of data about the plugin itself. may be extended in the future
     // 32 bit
     enum PluginString {
@@ -61,7 +59,6 @@ Interfaces that have to be exposed for the plugin to be loaded.
 ### PluginCallbacks001
 
 ```cpp
-
     struct PluginNorthstarData { HMODULE handle; };
 
     // COPY THE initData IT MAY BE MOVED AT RUNTIME
@@ -81,7 +78,6 @@ Interfaces are just abstract classes. So make sure the first parameter is always
 an example what NSSys001 looks like in C:
 
 ```cpp
-
     typedef enum {
       LOG_INFO,
       LOG_WARN,

--- a/docs/Modding/reference/northstar/chathooks.md
+++ b/docs/Modding/reference/northstar/chathooks.md
@@ -57,7 +57,6 @@ The client chat callbacks allow you to intercept chat messages and modify or blo
     **Example:**
 
     ```squirrel
-
         ClClient_MessageStruct function MyChatFilter(ClClient_MessageStruct message)
         {
             if (message.message.find("nft") != null)
@@ -89,7 +88,6 @@ players, they only display them locally.
     **Example:**
 
     ```squirrel
-
         void function OnGameStarted()
         {
             Chat_GameWriteLine("You got this, " + GetLocalClientPlayer().GetPlayerName() + "!")
@@ -104,7 +102,6 @@ players, they only display them locally.
     **Example:**
 
     ```squirrel
-
         void function InitialiseHEVSuit()
         {
             Chat_GameWriteLine("SENSOR ARRAYS-")
@@ -126,7 +123,6 @@ players, they only display them locally.
     **Example:**
 
     ```squirrel
-
         void function MyModInit()
         {
             Chat_NetworkWriteLine("MyMod v1.0.0 is good to go!")
@@ -141,7 +137,6 @@ players, they only display them locally.
     **Example:**
 
     ```squirrel
-
         void function OnButtonPressed()
         {
             Chat_NetworkWrite("Connecting in 3...")
@@ -194,7 +189,6 @@ The server chat callbacks allow you to intercept incoming chat messages and modi
     **Example:**
 
     ```squirrel
-
         ClServer_MessageStruct function MyChatFilter(ClServer_MessageStruct message)
         {
             if (message.message.find("nft") != null)
@@ -231,7 +225,6 @@ With custom messages you can send chat messages at any time, to all players or t
     **Example:**
 
     ```squirrel
-
         void function OnSayRedCommand(entity player, string text)
         {
             Chat_Impersonate(player, "red text -> \x1b[31m" + text)
@@ -254,7 +247,6 @@ With custom messages you can send chat messages at any time, to all players or t
     **Example:**
 
     ```squirrel
-
         void function OnSendToFriendsCommand(entity fromPlayer, string text)
         {
             array<entity> friends = GetPlayerFriends(fromPlayer)
@@ -278,7 +270,6 @@ With custom messages you can send chat messages at any time, to all players or t
     **Example:**
 
     ```squirrel
-
         void function RestartServerThread()
         {
             // wait one hour
@@ -312,7 +303,6 @@ With custom messages you can send chat messages at any time, to all players or t
     **Example:**
 
     ```squirrel
-
         void function OnBanCommand(entity player, array<string> args)
         {
             if (!PlayerIsModerator(player))
@@ -332,7 +322,6 @@ All messages support ANSI escape codes for customising text color. These are com
 meaning. For example, the string:
 
 ```text
-
     Hello world, \x1b[31mthis text is red\x1b[0m. And \x1b[34mthis text is blue\x1b[0m.
 ```
 

--- a/docs/Modding/reference/northstar/customdamagesources.md
+++ b/docs/Modding/reference/northstar/customdamagesources.md
@@ -19,7 +19,6 @@ Damage source IDs should be added in `"After"` server callbacks.
 For example, we can call the methods from a function in `damage_source_example.nut`:
 
 ```squirrel
-
     global function SimpleSourceInit
 
     void function SimpleSourceInit()
@@ -42,7 +41,6 @@ For example, we can call the methods from a function in `damage_source_example.n
 Then call the function as an `"After"` server callback in the `mod.json`:
 
 ```javascript
-
     {
         "Scripts": [
             {
@@ -59,7 +57,6 @@ Then call the function as an `"After"` server callback in the `mod.json`:
 Now, these damage source IDs can be referenced in script like so:
 
 ```squirrel
-
     eDamageSourceId.mp_weapon_minigun
     eDamageSourceId.mp_titanweapon_barrage_core_launcher
     eDamageSourceId.mp_titanweapon_grenade_launcher

--- a/docs/Modding/reference/northstar/dependencyconstants.md
+++ b/docs/Modding/reference/northstar/dependencyconstants.md
@@ -18,14 +18,12 @@ Contditons you can check for are
 These conditions can also be combined with the regular squirrel boolean expressions
 
 ```squirrel
-
     #if SERVER
     Chat_ServerBroadcast("Message from the server VM")
     #endif
 ```
 
 ```squirrel
-
     #if (CLIENT && MP) || DEV
     ...
     #elseif SP
@@ -41,7 +39,6 @@ loaded, these use the Compiler directives syntax.
 Inside your `mod.json` define a constant as:
 
 ```squirrel
-
     {
         // mod.json stuff
         "Dependencies": {
@@ -54,7 +51,6 @@ Inside your `mod.json` define a constant as:
 For Example:
 
 ```json
-
     "PLAYER_HAS_ROGUELIKE_MOD": "TF|Roguelike"
 ```
 
@@ -62,7 +58,6 @@ Will define a constant `PLAYER_HAS_ROGUELIKE_MOD` that is set to `0` or `1`
 depending if the mod is enabled. It then can be used as a constant/compiler flag.
 
 ```squirrel
-
     #if PLAYER_HAS_ROGUELIKE_MOD
     print("player has roguelike mod")
     Roguelike_Function();

--- a/docs/Modding/reference/northstar/httprequests.md
+++ b/docs/Modding/reference/northstar/httprequests.md
@@ -185,7 +185,6 @@ The HTTP system uses a few enums and structs for requests and their callbacks.
     such as `callback` in this example.
 
     ```squirrel
-
         HttpRequest request
         request.method = HttpRequestMethod.GET
         request.url = "https://my.spyglass.api/sanctions/get_by_id"
@@ -229,7 +228,6 @@ The HTTP system uses a few enums and structs for requests and their callbacks.
     This is the same example as NSHttpRequest()'s example. However, it uses this function instead.
 
     ```squirrel
-
         table<string, array<string> > params
         params[ "id" ] <- [ id.tostring() ]
 
@@ -291,7 +289,6 @@ The HTTP system uses a few enums and structs for requests and their callbacks.
     In this example, we'll convert a table to JSON, and send it over to a web API.
 
     ```squirrel
-
         table myData = {}
         myData[ "uid" ] <- player.GetUID()
         myData[ "username" ] <- player.GetPlayerName()

--- a/docs/Modding/reference/northstar/modsettings.md
+++ b/docs/Modding/reference/northstar/modsettings.md
@@ -7,7 +7,6 @@ ConVars are the easiest way to implement settings for your mod using the Mod Set
 Your mod needs to register itself and all ConVars that are a part of your mod that should be accessible in the Mod Settings menu. To do this, simply add a new script to your mod that runs only in the UI VM like this:
 
 ```json
-
   "Path": "ui/ms_example_mod.nut",
   "RunOn": "UI",
   "UICallback": {
@@ -121,7 +120,6 @@ Inside of the callback specified here, you can add your settings.
 To create custom wrapper functions you need to specify the stack position where the root of your Mod Setting declarations take place.
 
 ```squirrel
-
   void function AddModSettingsDropDown( string displayName, array<string> options )
   {
     NSModSettingsAddButton( displayName, void function() { OpenDropDown( options ) }, 3 )

--- a/docs/Modding/reference/northstar/serversiderui.md
+++ b/docs/Modding/reference/northstar/serversiderui.md
@@ -22,7 +22,6 @@ alt="/_static/serversiderui/vote.png" />
 **Example:**
 
 ```squirrel
-
     void function CreateDummyPoll()
      {
         array<string> options = [ "Vote for a map!", "Amongsus", "sussy", "when", "1.10", "hi H0l0" ]
@@ -42,7 +41,6 @@ alt="/_static/serversiderui/vote.png" />
 **Example:**
 
 ```squirrel
-
     void function CheckResponseToDummyPoll(entity player)
     {
         if(NSGetPlayerResponse(player) != -1)
@@ -67,7 +65,6 @@ alt="/_static/serversiderui/largemessage.gif" />
 **Example:**
 
 ```squirrel
-
     void function SendDummyLargeMessage(entity player)
     {
         NSSendLargeMessageToPlayer(player,"I'm not a dummy >:(", "You are", 10, "ui/fd_tutorial_tip.rpak")
@@ -91,7 +88,6 @@ alt="/_static/serversiderui/info.gif" />
 **Example:**
 
 ```squirrel
-
     void function SendDummyInfoMessage(entity player)
     {
         NSSendInfoMessageToPlayer(player, "we were sent at the same time but I was sent sooner")
@@ -115,7 +111,6 @@ alt="/_static/serversiderui/popup.gif" />
 **Example:**
 
 ```squirrel
-
     void funcions SendDummyPopUp(entity player)
     {
         NSSendPopUpMessageToPlayer(player, "very cool text I like")
@@ -139,7 +134,6 @@ alt="/_static/serversiderui/announcement.gif" />
 **Example:**
 
 ```squirrel
-
       void function SendDummyAnnouncement(entity player)
       {
           NSSendAnnouncementMessageToPlayer(player, "Very cool announcement", "Hi Karma", <1,1,0>, 1, ANNOUNCEMENT_STYLE_QUICK)
@@ -174,7 +168,6 @@ alt="/_static/serversiderui/status.gif" />
 **Examples:**
 
 ```squirrel
-
     void function TestStatusMessage_Threaded(entity player)
     {
         string id = UniqueString("votes#")

--- a/docs/Modding/reference/northstar/usefulfuncs.md
+++ b/docs/Modding/reference/northstar/usefulfuncs.md
@@ -364,7 +364,6 @@ Below are a list of useful functions added by Northstar.
         replaces text that should be localized on the client
 
         ```squirrel
-
             string localized = Localize( token )
         ```
 
@@ -377,7 +376,6 @@ Below are a list of useful functions added by Northstar.
         You can eliminate the possibility of the returned index being null by casting like this:
 
         ```squirrel
-
             int ornull index = GetMapName().find( "mp" )
 
             if( !index )

--- a/docs/Modding/reference/respawn/clientcommands.md
+++ b/docs/Modding/reference/respawn/clientcommands.md
@@ -7,7 +7,6 @@ Client commands are how the clients communicate with the server. Mods can define
     Registers a function as a callback for a client command. This can only be done once per client command string.
 
     ```squirrel
-
         AddClientCommandCallback("commandname", commandcallback)
 
         void CommandCalled(entity player, array<string> args) {

--- a/docs/Modding/reference/respawn/dialog.md
+++ b/docs/Modding/reference/respawn/dialog.md
@@ -98,7 +98,6 @@ All the data in the struct that can be changed.
     **Example**
 
     ```squirrel
-
         DialogData dialog
         dialog.message = "Hello there"
         OpenDialog( dialog )
@@ -117,7 +116,6 @@ All the data in the struct that can be changed.
     **Example**
 
     ```squirrel
-
         void function SendDialogWithButton()
         {
             DialogData dialog
@@ -152,7 +150,6 @@ All the data in the struct that can be changed.
 the folowing code produces this output:
 
 ```squirrel
-
     DialogData dialog
     dialog.header = "This is the header"
     dialog.message = "this is the body, it is green \n \n Hello There \n \n General Kenobi"

--- a/docs/Modding/reference/respawn/hud_element_notation.md
+++ b/docs/Modding/reference/respawn/hud_element_notation.md
@@ -10,7 +10,6 @@ It is not possible to create elements at runtime so you have to define all eleme
 An Element is declared in the following way:
 
 ```
-
     // please follow this structure
     ElementName
     {
@@ -26,7 +25,6 @@ An Element is declared in the following way:
 If you're working on a **menu**, you need a `menu` object that contains all elements, for example like this:
 
 ```
-
     resource/ui/menus/profiles_menu.menu
     {
         menu
@@ -60,7 +58,6 @@ It's not possible to load other files as menus or panels. A `.menu` represents a
 The rest of the file needs to be wrapped in curly brackets.
 
 ```
-
     resource/ui/menus/more/folders/my_menu.menu
     {
         MyObject
@@ -433,7 +430,6 @@ Usable conditions are:
     the game's language.
 
     ```text
-
             // use allcaps only in russian
             allCaps        0  [!$RUSSIAN]
             allCaps        1  [$RUSSIAN]
@@ -446,7 +442,6 @@ On top of that, logical operators like `!`, `&&` and `||` are available as well.
 #### Example:
 
 ```text
-
     // This element only shows on pc
     IngameTextChat [$WINDOWS]
     {
@@ -533,7 +528,6 @@ You can calculate the position or dimensions etc. with different units. If you p
     x percent of the screen.
 
     ```
-
         // cover the entire screen
         width   %100
         height  %100

--- a/docs/Modding/reference/respawn/hud_menus.md
+++ b/docs/Modding/reference/respawn/hud_menus.md
@@ -7,7 +7,6 @@ Before working on HUD, it's recommended to `extract <https://noskill.gitbook.io/
 In your `mod.json`, add a `Before` UI callback like this:
 
 ```json
-
         {
             "Path": "ui/profiles_menu.nut",
             "RunOn": "UI",
@@ -20,7 +19,6 @@ In your `mod.json`, add a `Before` UI callback like this:
 In the script you referenced, create a global in which you register your menu with the `AddMenu` like this:
 
 ```squirrel
-
     global function InitProfilesMenu
 
     void function InitProfilesMenu()
@@ -36,7 +34,6 @@ The returns `void` and takes no parameters. It gets called once the menu is init
 It's recommended to create a file struct in which you store menu states:
 
 ```squirrel
-
     struct {
         var menu
     } file
@@ -191,7 +188,6 @@ Not recommended to use.
 To use footers, add this element to your menu:
 
 ```
-
     FooterButtons
     {
         ControlName         CNestedPanel

--- a/docs/Modding/reference/respawn/movers.md
+++ b/docs/Modding/reference/respawn/movers.md
@@ -61,7 +61,6 @@ Movers are entites that move and rotate smoothly.
 ## Examples
 
 ```squirrel
-
     entity mover = CreateScriptMover( <0,0,0> )
 
     // moving the mover to <0,0,10> in 1 second
@@ -80,7 +79,6 @@ Movers are entites that move and rotate smoothly.
 ```
 
 ```squirrel
-
     // creating a elevator
     // using a mover with a model
     entity mover = CreateScriptMoverModel( $"models/props/turret_base/turret_base.mdl", < -40.5605, -1827.87, -223.944 >, <0,0,0>, SOLID_VPHYSICS, 1000 )
@@ -99,7 +97,6 @@ Movers are entites that move and rotate smoothly.
 ```
 
 ```squirrel
-
     // Phase shifting the player to a destination
     // setting a position
     vector destination = <250,1000,100>

--- a/docs/Modding/reference/respawn/rui.md
+++ b/docs/Modding/reference/respawn/rui.md
@@ -3,7 +3,6 @@
 Functions for creating a rui, and methods of the rui object
 
 ```squirrel
-
             // To create one, do:
             rui = RuiCreate( $"ui/assetname.rpak", topology, drawGroup, sortKey ) // sortkey = int to prevent z-fighting. higher -> in front
 
@@ -24,7 +23,6 @@ Functions for creating a rui, and methods of the rui object
 Drawgroups
 
 ```
-
         RUI_DRAW_WORLD
         RUI_DRAW_HUD
         RUI_DRAW_COCKPIT
@@ -34,7 +32,6 @@ Drawgroups
 Trackers
 
 ```
-
         // VECTOR TYPES
         RUI_TRACK_ABSORIGIN_FOLLOW                   // Create at absorigin, and update to follow the entity
         RUI_TRACK_POINT_FOLLOW                       // Create on attachment point, and update to follow the entity
@@ -95,7 +92,6 @@ Trackers
     !!! cpp-function "void RuiSetResolution(rui, screenSizeX, screenSizey)"
 
         ```squirrel
-
                 screenSizeX = GetScreenSize()[0]
                 screenSizeY = GetScreenSize()[1]
         ```

--- a/docs/Modding/reference/respawn/titan.md
+++ b/docs/Modding/reference/respawn/titan.md
@@ -3,7 +3,6 @@
 Functions for getting titan, and methods of the titan object
 
 ```squirrel
-
             entity soul = player.IsTitan() ? player.GetTitanSoul() : player.GetPetTitan().GetTitanSoul()
             // getting the titan depends on wether the player is in the titan or not
 ```

--- a/docs/Modding/reference/respawn/topology.md
+++ b/docs/Modding/reference/respawn/topology.md
@@ -7,7 +7,6 @@ The position of topologies are relative to the position of their parent.
 Since the number of topologies that can be created is very limited and Vanilla uses most of the slots already, try to minimize your topology uses. Instead of creating new ones, check if you can use one that already exists:
 
 ```squirrel
-
             clGlobal.topoFullScreen
             clGlobal.topoCockpitHudPermanent
             clGlobal.topoTitanCockpitLowerHud
@@ -59,7 +58,6 @@ Drawcalls determine how and where RUIs on a topology are being rendered.
 ## HUD Topology example
 
 ```squirrel
-
     // Cover the top left quadrant of the screen with a basic image
     float[2] s = GetScreenSize()
     var topo = RuiTopology_CreatePlane( <0,0,0>, <s[0] / 2,0,0>, <0,s[1] / 2,0>, true ) // RUIs scale with the topology they are being drawn on so make sure to use the correct dimensions
@@ -69,7 +67,6 @@ Drawcalls determine how and where RUIs on a topology are being rendered.
 ## Worldspace Topology example
 
 ```squirrel
-
     // REMEMBER TO DESTROY ALL TOPOS, RUIS AND PROPS YOU CREATE WHEN YOU NO LONGER NEED THEM
     // ripped from respawn
     var function Worldspace_CreateRUITopology( vector org, vector ang, float width, float height )

--- a/docs/Modding/repak/assets/datatable.md
+++ b/docs/Modding/repak/assets/datatable.md
@@ -5,7 +5,6 @@
 ### 1. Example Datatable Asset
 
 ```json
-
     {
         "$type": "dtbl",
         "path": "datatable/custom_datatable",

--- a/docs/Modding/repak/assets/texture.md
+++ b/docs/Modding/repak/assets/texture.md
@@ -28,7 +28,6 @@ following compression types:
 ### 1. Basic Texture Asset - No streaming
 
 ```json
-
     {
         "$type": "txtr",
         "path": "textures/models/humans/test_texture",
@@ -49,7 +48,6 @@ following compression types:
 ### 2. Streamed Texture Asset
 
 ```json
-
     {
         "$type": "txtr",
         "path": "textures/models/humans/test_texture_2",

--- a/docs/Modding/repak/assets/uiatlas.md
+++ b/docs/Modding/repak/assets/uiatlas.md
@@ -9,7 +9,6 @@ reference a single texture asset, known as the `atlas` and have an array of
 ### 1. Basic UI Image Atlas with 2 Textures
 
 ```json
-
     {
         "$type":"uimg",
         "path":"rui/atlas/example1",
@@ -42,7 +41,6 @@ reference a single texture asset, known as the `atlas` and have an array of
 ### 2. Full Map File With a UI Image Atlas
 
 ```json
-
     {
         "name":"blue_fire",
         "assetsDir":"../depot",

--- a/docs/Modding/repak/map.md
+++ b/docs/Modding/repak/map.md
@@ -7,14 +7,12 @@
 `example1.json`
 
 ```json
-
     {
         "version": 7
     }
 ```
 
 ```text
-
     root
     ├── RePak.exe
     ├── example1.json
@@ -35,7 +33,6 @@
 `example2.json`
 
 ```json
-
     {
         "name": "example2",
         "assetsDir": "../depot",
@@ -53,7 +50,6 @@
 ```
 
 ```text
-
     root
     ├── RePak.exe
     ├── maps
@@ -84,7 +80,6 @@
 `example3.json`
 
 ```json
-
     {
         "name": "example3",
         "assetsDir": "../depot",
@@ -111,7 +106,6 @@
 ```
 
 ```text
-
     root
     ├── RePak.exe
     ├── maps

--- a/docs/Modding/squirrel/async.md
+++ b/docs/Modding/squirrel/async.md
@@ -17,7 +17,6 @@ A thread is considered finished, after the threaded function returned a value. T
 To create a new coroutine, call a function with the `thread` keyword before.
 
 ```squirrel
-
     thread void function(){}()
     thread MyFunction()
 ```
@@ -25,7 +24,6 @@ To create a new coroutine, call a function with the `thread` keyword before.
 To get a thread object, use the `newthread` function.
 
 ```squirrel
-
     void function CoroutineExample()
     {
         suspend( "passback" ) // passback is optional
@@ -58,7 +56,6 @@ When using infinite loops it's important to work with `wait` statements to avoid
 If you want to wait until a thread is finished, you can spin off the thread that you wait for with the `waitthread` keyword.
 
 ```squirrel
-
     void function ParentThread()
     {
         printt( "pre spinoff " + string( Time() ) )
@@ -76,7 +73,6 @@ If you want to wait until a thread is finished, you can spin off the thread that
 Use the `OnThreadEnd` function to execute a callback after a thread has ended. This is useful for cleanup functions that remove entities after they're used or similar.
 
 ```squirrel
-
     void function PlayIncomingFX( vector origin, int teamNum )
     {
         wait 1.50
@@ -106,7 +102,6 @@ Use the `OnThreadEnd` function to execute a callback after a thread has ended. T
 ### Example Script
 
 ```squirrel
-
     void function SetPositionDelayed( entity ent, vector pos, float delay )
     {
         wait delay
@@ -175,7 +170,6 @@ It's also possible to trigger and catch signals with methods that aren't propert
     Wait for any of the passed signals to be triggered.
 
     ```squirrel
-
         // Wait for the NPC to die, delete, or get leeched, then remove the npc from the array
         WaitSignal( ent, "OnDeath", "OnDestroy", "OnLeeched" )
     ```
@@ -189,7 +183,6 @@ It's also possible to trigger and catch signals with methods that aren't propert
 For example, if we want to tell a player not to give up after being killed several times, we can write it this way:
 
 ```squirrel
-
     // First, we register signal we want to use
     RegisterSignal("OnMultipleDeaths")
 
@@ -312,7 +305,6 @@ is set, thread will end (after calling any `OnThreadEnd` methods).
 #### Example
 
 ```squirrel
-
     void function FlagExample()
     {
         FlagInit( "BombHasExploded" )

--- a/docs/Modding/squirrel/class.md
+++ b/docs/Modding/squirrel/class.md
@@ -13,7 +13,6 @@ To declare a class, first add the `untyped` keyword and the class as a variable 
 file level.
 
 ```squirrel
-
     untyped
     var ExampleClass
 ```
@@ -35,7 +34,6 @@ Most classes use a constructor. A constructor is a function of the instance that
 executed on object creation.
 
 ```squirrel
-
     void function initClient() {
         class ExampleClass {
             constructor(){print("Instance of ExampleClass created");}
@@ -51,7 +49,6 @@ Function parameters are passed as type `var`, but the type keyword is not requir
 ){}; func( var parameter ){};` are both correct.
 
 ```squirrel
-
     class ExampleClass {
             propertyString = null // Actual type is var
             propertyInt = null // Actual type is var
@@ -75,7 +72,6 @@ Every object has a reference to itself called `this`. You can change parameters 
 object by reference.
 
 ```squirrel
-
     void function initClient() {
         class ExampleClass {
             property = null
@@ -95,7 +91,6 @@ Functions of a class have to return a value of type `var`. This may be `null`.
 Define functions like this:
 
 ```squirrel
-
     global var ExampleClass;
     void function initClassF(){
         class ExampleClass {
@@ -124,7 +119,6 @@ It's possible to insert more properties into a class at runtime. To achieve this
 the `<-` operator.
 
 ```squirrel
-
     // Using `ExampleClass` and `exampleObject` from example above
     ExampleClass.newProperty <- "New property in class"
     // The value of the new index may be of any type.
@@ -150,7 +144,6 @@ the `<-` operator.
 Inserting functions is also possible using the `::` operator
 
 ```squirrel
-
     function ExampleClass::AddOne( var param /* parameters have to be var */ ){ return expect int( param ) + 1 }
     var e = ExampleClass()
     print( expect int( e.AddOne( 1 ) ) ) // prints 2
@@ -196,7 +189,6 @@ inherited from a modified class.
 To create an instance, do:
 
 ```squirrel
-
     class ExampleClass {
         property = null
         constructor( var parameter ) {
@@ -213,7 +205,6 @@ To create an instance, do:
 It's also possible to create an instance without calling the constructor.
 
 ```squirrel
-
     // Using 'ExampleClass' from previous examples
     var e = ExampleClass.instance()
     e.constructor(1) // Constructor is a normal function so you can call it manually.
@@ -227,7 +218,6 @@ doesn't have a reference to itself, meaning that the `this` keyword refers to th
 table.
 
 ```squirrel
-
     var class = ExampleClass
     var instance = class.constructor()
 ```
@@ -239,7 +229,6 @@ reference to itself. This means that any modifications inside of a function are 
 to the original object.
 
 ```squirrel
-
     void function initClass(){
         class Container {
             content = null
@@ -261,7 +250,6 @@ You can avoid this by using cloned objects. Use the `clone` keyword to create a 
 of an object.
 
 ```squirrel
-
     // Assumes the 'Container' class from the previous example has already been declared
     void function initClass(){
         var originalObj = Container("original string")
@@ -283,7 +271,6 @@ hold multiple class objects that emulate the behaviour of namespaces to a certai
 extend.
 
 ```squirrel
-
     global table<string, var> fakeNamespace = {
             class1 = null,
             class2 = null
@@ -295,7 +282,6 @@ This allows you to group classes together in a single global variable.
 You can use the classes inside of the table like this:
 
 ```squirrel
-
     // Create a class object in field
     class fakeNamespace.class1 { constructor(){ print("constructing instance of class1") } }
     class fakeNamespace.class2 { constructor(){ print("constructing instance of class2") } }
@@ -311,7 +297,6 @@ You can use the classes inside of the table like this:
 You can also declare classes in an array:
 
 ```squirrel
-
     array<var> classes // This has to be at file level
 
     // This has to be inside of a function:
@@ -322,7 +307,6 @@ You can also declare classes in an array:
 And in a similar fashion in structs:
 
 ```squirrel
-
     struct {
             var class1 = null
             var class2 = null
@@ -341,7 +325,6 @@ And in a similar fashion in structs:
     won't compile.
 
     ```squirrel
-
         class Child extends Parent{}
     ```
 

--- a/docs/Modding/squirrel/cpp_api/objecthandling.md
+++ b/docs/Modding/squirrel/cpp_api/objecthandling.md
@@ -152,7 +152,6 @@
     Used to add global constants for scripts.
 
     ```cpp
-
         getConstants(sqvm);
 
         pushstring(sqvm, "MY_CONSTANT");
@@ -173,7 +172,6 @@
     returns `0` if the function was found.
 
     ```cpp
-
         SQObject functionobj {};
         int result = sq_getfunction(m_pSQVM->sqvm, funcname, &functionobj, 0);
         if (result != 0) // This func returns 0 on success for some reason
@@ -214,7 +212,6 @@
     More information about function calls are available [here](sq_functions.md)
 
     ```cpp
-
         ADD_SQFUNC("void", SQCallbackTest, "void functionref()", "", ScriptContext::UI)
         {
             SQObject fn; // Make an empty sqobject. This will hold the function object later

--- a/docs/Modding/squirrel/cpp_api/objectmanipulation.md
+++ b/docs/Modding/squirrel/cpp_api/objectmanipulation.md
@@ -13,7 +13,6 @@
     creates a new array and pushes it to the stack
 
     ```cpp
-
         newarray(sqvm, 0);
         pushstring(sqvm, "val1");
         arrayappend(sqvm, -2);
@@ -57,7 +56,6 @@
     pops a key and a value from the stack and performs a set operation on the table or class that is at position idx in the stack, if the slot does not exist it will be created.
 
     ```cpp
-
         newtable(sqvm);
         // slot 1
         pushstring(sqvm, "key");
@@ -108,7 +106,6 @@
     Pops a value from the stack and fills the field at `fieldIndex` from the struct object that needs to be at the top of the stack.
 
     ```cpp
-
         pushnewstructinstance(sqvm, 2); // create a struct instance with 2 slots
         pushinteger(sqvm, 12);
         sealstructslot(sqvm, 0);

--- a/docs/Modding/squirrel/cpp_api/sq_functions.md
+++ b/docs/Modding/squirrel/cpp_api/sq_functions.md
@@ -22,7 +22,6 @@ Parameters are the initial stack in the function context.
 Return a string from a native registered function:
 
 ```cpp
-
     ADD_SQFUNC("string", CPlugTest, "", "returns \"native gaming\"", ScriptContext::CLIENT | ScriptContext::SERVER)
     {
         g_pSquirrel<context>->pushstring(sqvm, "native gaming"); // push a string to the stack
@@ -34,7 +33,6 @@ Return a string from a native registered function:
 Return a complex `ornull` type:
 
 ```cpp
-
     ADD_SQFUNC("array<int> ornull", CPlugComplex, "int n", "returns null", ScriptContext::CLIENT | ScriptContext::SERVER | ScriptContext::UI)
     {
         SQInteger n = g_pSquirrel<context>->getinteger(sqvm, 1);
@@ -73,7 +71,6 @@ It's also possible to add an override directly with the `AddFuncOverride` functi
     - `SQFunc func` A function object that replaces the logic
 
 ```cpp
-
     // Replaces dangerous vanilla functions to only log their call with no further logic.
     g_pSquirrel<context>->AddFuncOverride("DevTextBufferWrite", SQ_StubbedFunc<context, "DevTextBufferWrite">);
     g_pSquirrel<context>->AddFuncOverride("DevTextBufferClear", SQ_StubbedFunc<context, "DevTextBufferClear">);
@@ -116,7 +113,6 @@ Squirrel functions need to return a `SQRESULT`. Valid results are
     If you want to call into squirrel asynchronously, use `AsyncCall`_ instead.
 
     ```cpp
-
         Call("PluginCallbackTest"); // PluginCallbackTest()
     ```
 
@@ -131,7 +127,6 @@ Squirrel functions need to return a `SQRESULT`. Valid results are
         This is a squirrel API wrapper added by northstar. It's not available for plugins and is supposed to abstract squirrel calls.
 
     ```cpp
-
         Call("PluginCallbackTest", "param"); // PluginCallbackTest("param")
     ```
 
@@ -172,7 +167,6 @@ Squirrel functions need to return a `SQRESULT`. Valid results are
         This is a squirrel API wrapper added by northstar. It's not available for plugins and is supposed to abstract squirrel calls.
 
     ```cpp
-
         SQObject functionobj {};
         SQRESULT result = g_pSquirrel<context>->sq_getfunction(sqvm, "PluginCallbackTest", &functionobj, 0); // Get a global squirrel function called "PluginCallbackTest"
 
@@ -212,7 +206,6 @@ Squirrel functions need to return a `SQRESULT`. Valid results are
     Throws an error with `error` being the thrown object.
 
     ```cpp
-
         ADD_SQFUNC("void", CPlugThrowTest, "", "", ScriptContext::UI)
         {
             return g_pSquirrel<context>->raiseerror(sqvm, "test error");

--- a/docs/Modding/squirrel/functions.md
+++ b/docs/Modding/squirrel/functions.md
@@ -9,7 +9,6 @@ Functions in squirrel are defined with this syntax: `<return type> function <nam
 For example, a simple function that returns either `true` or `false` would look like this:
 
 ```squirrel
-
   bool function CoinFlip()
   {
     return RandomInt( 2 ) == 0 // generate a random number from 0 - 1
@@ -25,7 +24,6 @@ If you need some data after a function is finished (for example after a calculat
 You can return anything, however the type of the returned variable needs to match with the return type of the function.
 
 ```squirrel
-
    string function GetNorthstarName()
    {
     return "Northstar" // this would be valid
@@ -40,7 +38,6 @@ If you don't want to return any value, use `void` as the return type. This indic
 If nothing is returned by a function, `null` will get returned implicitly.
 
 ```squirrel
-
   void function ReturnNull()
   {
     // return null regardless what happens, this all does the same
@@ -64,7 +61,6 @@ In `untyped` files you may leave out the return type. In those cases the return 
 Parameters are the input a function gets when called. They are local variables whose values come from the calling function.
 
 ```squirrel
-
    void function main()
    {
     int refcount = 0
@@ -85,7 +81,6 @@ Sometimes you need parameters that are optional for a function, like extra optio
 Optional parameters need to be the last parameters of a function.
 
 ```squirrel
-
    void function main()
    {
     array a = [ 1, 2, 3, 4 ]
@@ -111,7 +106,6 @@ With vargs you can pass a function an unlimited amount of parameters. The parame
 You can denote a function to have vargs with adding `...` to the end of the parameter list.
 
 ```squirrel
-
    string function CombineStuff( string base, ... )
    {
     string s = base
@@ -127,7 +121,6 @@ You can denote a function to have vargs with adding `...` to the end of the para
 Closures are functions that are anonymous (unnamed) functions created in a specific script context that can use variables from the parent scope.
 
 ```squirrel
-
    void function main()
    {
     void functionref() fn = void function(){ print( "I'm a closure" ) } // create a closure
@@ -138,7 +131,6 @@ Closures are functions that are anonymous (unnamed) functions created in a speci
 Closures can capture variables from their parent scope.
 
 ```squirrel
-
    void function PlayFXOnEntity( entity ent )
    {
       int fxHandle = StartParticleEffectOnEntity( ent, PILOT_THROWN_TICK_WARNING, FX_ATTACH_POINT_FOLLOW, ent.LookupAttachment( "head_base" )

--- a/docs/Modding/squirrel/intro.md
+++ b/docs/Modding/squirrel/intro.md
@@ -11,7 +11,6 @@ The syntax of squirrel is very similar to C++ or Javascript and very easy to lea
 The programmer doesn't need to think about memory management in scripts since all objects are refcounted and the garbage collector can be invoked manually.
 
 ```squirrel
-
    int function fibonacci( int n )
    {
     if ( n < 2 )
@@ -24,7 +23,6 @@ The programmer doesn't need to think about memory management in scripts since al
 The language provides easy interfaces for coroutines and asynchronous code.
 
 ```squirrel
-
    void main()
    {
     thread timer( 1.0, timercallback )
@@ -51,7 +49,6 @@ The language provides easy interfaces for coroutines and asynchronous code.
 Signals and Flags allow you to control code execution based on events that happen elsewhere in the code or in the ingame world.
 
 ```squirrel
-
    void main()
    {
     AddCallback_OnPlayerRespawned( OnPlayerRespawned )

--- a/docs/Modding/squirrel/networking.md
+++ b/docs/Modding/squirrel/networking.md
@@ -33,7 +33,6 @@ function. It's not possible to register remote functions after `Remote_EndRegist
 mod.json extract:
 
 ```json
-
         "Scripts": [
         {
             "Path": "sh_spaceships.nut",
@@ -54,7 +53,6 @@ sh_spaceships.nut:
 The networked `CLIENT` function has to be global
 
 ```squirrel
-
     #if CLIENT
     global function Server_GetNetworkedVariable // make the networked function only global on CLIENT
     #endif //CLIENT
@@ -83,7 +81,6 @@ The networked `CLIENT` function has to be global
 Calling the `CLIENT` function `Server_GetNetworkedVariable` on `SERVER` vm:
 
 ```squirrel
-
     // player: CPlayer entity that should execute the function
     // func: function identifier string
     // ...: any parameters passed to the function
@@ -120,7 +117,6 @@ and execute with the function serverside:
 #### Example
 
 ```squirrel
-
     void function MessageUtils_ClientInit()
     {
         AddServerToClientStringCommandCallback( "ServerHUDMessageShow", ServerCallback_CreateServerHUDMessage )
@@ -141,7 +137,6 @@ and execute with the function serverside:
 #### Example
 
 ```squirrel
-
     Remote_CallFunction_UI( player, "ScriptCallback_UnlockAchievement", achievementID )
 ```
 
@@ -170,7 +165,6 @@ Since version 1.5 mods can receive notifications when a client command has been 
     Example usage with the :doc:`PrivateMatchLaunch` clientcommand
 
     ```squirrel
-
         void function init(){
             AddClientCommandNotifyCallback("PrivateMatchLaunch", started)
         }
@@ -218,7 +212,6 @@ You can also pass parameters to the function. `identifier` is the name of the fu
 #### Example
 
 ```squirrel
-
     #if CLIENT
     global function CallMe
 

--- a/docs/Modding/squirrel/statements.md
+++ b/docs/Modding/squirrel/statements.md
@@ -5,7 +5,6 @@
 If statements use a similar style to most programming languages and will execute their asigned code if the test placed inside returns the boolean value true. If I wanted to have something occur if, and only if, our previous `ReturnTrueOrFalse` function returned true, then you can use:
 
 ```squirrel
-
   if( ReturnTrueOrFalse() )
 ```
 
@@ -21,7 +20,6 @@ Squirrel supports ternary operations like most languages. The value of the expre
 The Syntax is `condition ? if_condition_true : if_condition_false`. This is especially useful when declaring variables or passing parameters.
 
 ```squirrel
-
   // shortenedUsername is "longus..."" if username is "longusername" or "short" if username is "short"
   string shortenedUsername = username.len() > 9 ? username.slice(0,6) + "..." : username;
 ```
@@ -35,7 +33,6 @@ Loops are used to execute the same code n times.
 A while loop runs as long as the condition evaluates to a truthy value.
 
 ```squirrel
-
   while( true )
   {
     // this will result in an endless loop because the probe condition will never be false
@@ -52,7 +49,6 @@ A while loop runs as long as the condition evaluates to a truthy value.
 A do while loop is the same as a while loop but the condition is checked **after** the body is executed.
 
 ```squirrel
-
   do
   {
     // this will execute only one time
@@ -66,7 +62,6 @@ A for loop also runs until a condition is met however it provides you with a cou
 The Syntax is as follows: `for( int counter; condition; behaviour_after_body_execution )`
 
 ```squirrel
-
   // prints 0, 1, 2, 3, 4
   for( int i; i < 5; i++ )
   {
@@ -86,7 +81,6 @@ The Syntax is as follows: `for( int counter; condition; behaviour_after_body_exe
 A foreach loop iterates over a `table` or an `array` and executes for each entry. The loop provides you with an optional counter for arrays or key for tables.
 
 ```squirrel
-
   array<int> arr = [ 1, 2, 3, 4 ]
   table<string, string> map = {
     key1 = "mapped value 1",
@@ -111,12 +105,10 @@ A foreach loop iterates over a `table` or an `array` and executes for each entry
 Conditional statements, such as while loops and if statements, also implictly cast non-boolean inputs to booleans. For numbers, this means 0 is considered false and anything else is considered true. For instance variables like arrays and entities, `null` is considered false and anything else is considered true. For example, these inputs are considered true by the if statements:
 
 ```squirrel
-
   if(2)
 ```
 
 ```squirrel
-
   array somelist = [0, 1]
   if(somelist)
 ```
@@ -129,7 +121,6 @@ So great, we can loop and check things, but what can we do with this information
 For example, lets make our `ReturnTrueOrFalse` function, that randomly picks either true or false, first:
 
 ```squirrel
-
   bool function ReturnTrueOrFalse() {
     return RandomInt(2) == 1
   }
@@ -139,7 +130,6 @@ Note that while functions always need `{}`, single-line `if`/`else` statements a
 
 
 ```squirrel
-
   if(ReturnTrueOrFalse())
     printt("Only called if true")
 ```
@@ -147,7 +137,6 @@ Note that while functions always need `{}`, single-line `if`/`else` statements a
 Now let's make a more complicated function that will use the previous script to determine true or false, printing a list each time it returns true:
 
 ```squirrel
-
   array<int> someinformation = [1,2,3,4,5,6]
   void function ThisDoesStuff(){
     while(ReturnTrueOrFalse()){

--- a/docs/Modding/squirrel/statements/controlflow.md
+++ b/docs/Modding/squirrel/statements/controlflow.md
@@ -7,7 +7,6 @@ Squirrel supports most basic control flow statements.
 `if` statements check if a condition evaluates to `true`.
 
 ```squirrel
-
    if ( expression )
     body
 ```

--- a/docs/Modding/squirrel/types/arrays.md
+++ b/docs/Modding/squirrel/types/arrays.md
@@ -15,7 +15,6 @@ Arrays are always zero indexed with `[ <expression> ]`. The indexes are always n
 Array literals are a comma or newline seperated sequence of expressions delimited by an opening bracket `[` and a corresponding closing bracket `]`.
 
 ```squirrel
-
   array a = [ 1, 2, 3 ]
   array b = [
     1
@@ -29,7 +28,6 @@ Array literals are a comma or newline seperated sequence of expressions delimite
 Primitive arrays are arrays that can hold any value. Their content is therefore untyped.
 
 ```squirrel
-
   array a
   a.append( 1 ) // add a number
   a.append( "str" ) // add a string
@@ -50,7 +48,6 @@ The content type needs to be specified within `<` and `>` brackets.
 There is no way to define a complex array that holds multiple different types.
 
 ```squirrel
-
    array<int> a
    a.append( 1 )
    a.append( 0x2 )
@@ -71,7 +68,6 @@ You can index and change content values like with regular arrays.
 When initializing a static array you can omit all values after your initial values with `...`. All following values will get default initialized with the content's default.
 
 ```squirrel
-
    float[3] v1
    float[8] v2 = [ 1.0, 2.0, ... ]
    v2[2] = 3.0
@@ -87,7 +83,6 @@ It is not possible to cast or convert an array between their different forms. Fo
 Instead you need to create an entirely new array with the target type or add all contents manually.
 
 ```squirrel
-
   array<string> orig = [ "a", "b", "c" ]
   array target
 

--- a/docs/Modding/squirrel/types/booleans.md
+++ b/docs/Modding/squirrel/types/booleans.md
@@ -5,7 +5,6 @@ Booleans are a primitive type that can be either `true` or `false`
 The type name and keyword for Booleans is `bool`. Booleans default initialize as `false`.
 
 ```squirrel
-
    bool b = false
    b = true
 ```

--- a/docs/Modding/squirrel/types/entities.md
+++ b/docs/Modding/squirrel/types/entities.md
@@ -11,7 +11,6 @@ You can not specify which entity class a variable is supposed to hold so you nee
 If you need to check the class of an entity at runtime you can do so with the `instanceof` operator.
 
 ```squirrel
-
    bool function IsCPlayer( entity e )
    {
     return e instanceof CPlayer
@@ -21,7 +20,6 @@ If you need to check the class of an entity at runtime you can do so with the `i
 Entities are `null` initialized and there are no literals for entities.
 
 ```squirrel
-
    entity e
    Assert( e == null )
 ```

--- a/docs/Modding/squirrel/types/floats.md
+++ b/docs/Modding/squirrel/types/floats.md
@@ -13,7 +13,6 @@ Float literals need to contain a `.` to distinguish them from integer literals.
 They may omit the decimal before the period, however after the period a value is required.
 
 ```squirrel
-
   float a = 1.1
   float b = 0.0
   float c = .0 // 0.0

--- a/docs/Modding/squirrel/types/functionrefs.md
+++ b/docs/Modding/squirrel/types/functionrefs.md
@@ -5,7 +5,6 @@ Function references are a complex type that can reference any function or closur
 The type keyword is `functionref` and needs to include any parameter types and optionally return types.
 
 ```squirrel
-
    void function CallDelayed( void functionref() fn )
    {
     wait 1
@@ -18,7 +17,6 @@ You can call functionrefs like a regular function. The return type of a function
 Parameter names are optional in functionrefs. Otherwise the parameter syntax is like in regular functions.
 
 ```squirrel
-
    void function Example( int n, ... ) {}
 
    void functionref( int, ... ) fn = Example

--- a/docs/Modding/squirrel/types/integers.md
+++ b/docs/Modding/squirrel/types/integers.md
@@ -14,7 +14,6 @@ Integers can be represented with multiple different literals.
 
     Regular decimal letters will always be an integer decimal literal.
     ```squirrel
-
     int n = 123
     ```
 
@@ -23,7 +22,6 @@ Integers can be represented with multiple different literals.
     If any number is prefixed with `0x`, it is a hexadecimal literal.
 
     ``` squirrel
-
     int n = 0x0012 // 18
     ```
 
@@ -32,7 +30,6 @@ Integers can be represented with multiple different literals.
     Numbers starting with a `0` are octal literals.
 
     ``` squirrel
-
     int n = 075 // 61
     ```
 
@@ -41,7 +38,6 @@ Integers can be represented with multiple different literals.
     A single letter or escaped sequence are character literals. Their value is the ASCII value of the letter.
 
     ``` squirrel
-
     int a = 'a' // 97
     int newline = '\n' // 10
     ```

--- a/docs/Modding/squirrel/types/ornull.md
+++ b/docs/Modding/squirrel/types/ornull.md
@@ -8,7 +8,6 @@ This is required for nesting structs inside themselves to ensure they are fixed 
 To use the value of an `ornull` variable you need to ensure that it is not `null` and then cast to the correct type.
 
 ```squirrel
-
    int ornull n = null
    n = 1
 
@@ -26,7 +25,6 @@ Being required to cast the value of `ornull` variables makes it impossible to us
 You can use `ornull` types in complex type as well, for example in complex arrays.
 
 ```squirrel
-
    array<int ornull> a = [ 1, null ]
    a.append( 2 )
    a.append( null )
@@ -35,7 +33,6 @@ You can use `ornull` types in complex type as well, for example in complex array
 Additionally, `ornull` is useful for adding optional parameters to functions that need to preserve backwards compatability.
 
 ```squirrel
-
    SomeAPIFunction( int ornull n = null ) {}
 
    // both are valid

--- a/docs/Modding/squirrel/types/strings.md
+++ b/docs/Modding/squirrel/types/strings.md
@@ -20,7 +20,6 @@ Verbatim strings can also extend over multiple lines.
 If they do they include any white space between the matching string quotes.
 
 ```squirrel
-
   string a = "simple string\nover two lines"
   string b = @"simple string
   over two lines"
@@ -31,7 +30,6 @@ If they do they include any white space between the matching string quotes.
 However, a doubled quotation mark within a verbatim string is replaced by a single quotation mark.
 
 ```squirrel
-
   string a = "extra quotation mark\""
   string b = @"extra quotation mark """
 
@@ -49,7 +47,6 @@ The type keyword for assets is `asset`.
 Asset literals are regular string literals prefixed with the `$` token. Verbatim strings can't be an asset.
 
 ```squirrel
-
   asset a = $"my/resource"
 ```
 

--- a/docs/Modding/squirrel/types/structs.md
+++ b/docs/Modding/squirrel/types/structs.md
@@ -9,7 +9,6 @@ Before using a struct you need to define it and all contents.
 The fields are typed like any regular variable.
 
 ```squirrel
-
    struct MyStruct
    {
     int field1
@@ -23,7 +22,6 @@ Structs are default initialized by assigning each field it's appropriate default
 Struct fields can be indexed by writing `instance.field`, just like with tables.
 
 ```squirrel
-
   MyStruct myStructInstance
   printt( myStructInstance.field1 ) // 0
 ```
@@ -35,7 +33,6 @@ Struct instances can also get initiaized with different default values if requir
 Similar like in static arrays, you can omit any fields that should have their type's default value with `...`.
 
 ```squirrel
-
    MyStruct ins = { field3 = [], field1 = 1, ... }
    printt( ins.field1, ins.field2 ) // 1, ""
 ```
@@ -45,7 +42,6 @@ Similar like in static arrays, you can omit any fields that should have their ty
 Struct fields can be any type, this includes previously declared structs as well.
 
 ```squirrel
-
    struct Engine
    {
     string manufacturer
@@ -68,7 +64,6 @@ Struct fields can be any type, this includes previously declared structs as well
 Structs can contain fields of their own type, however they need to be **null initialized**. You can achieve this by specifying their type as `ornull`.
 
 ```squirrel
-
    struct LinkedList
    {
     var content
@@ -83,7 +78,6 @@ Any struct field can have an optional default value. If omitted, the type's defa
 Default values need to be a constant expression that can be evaluated at compile time.
 
 ```squirrel
-
    struct Dice
    {
     int[6] sides = [ 1, 2, 3, 4, 5, 6 ]
@@ -95,7 +89,6 @@ Default values need to be a constant expression that can be evaluated at compile
 You can define a struct and initialize a local variable of that struct instantly with singletons. These are often used to have global variables that are only used in a single script file.
 
 ```squirrel
-
    struct {
     var menu
    } file
@@ -109,7 +102,6 @@ You can define a struct and initialize a local variable of that struct instantly
 Singletons can also be used for struct fields.
 
 ```squirrel
-
    struct Car
    {
     struct {

--- a/docs/Modding/squirrel/types/tables.md
+++ b/docs/Modding/squirrel/types/tables.md
@@ -11,7 +11,6 @@ The type keyword is `table`.
 To index an array with a string you can write `t.index`, or with an expression just like in arrays with `t.["index"]`.
 
 ```squirrel
-
    table t = { val = "value" }
    string v = t.val
    string v2 = t["val"]
@@ -26,7 +25,6 @@ Each entry needs to have a key, seperated from the initial value with a `=`.
 Table keys will be by default strings if you just write their identifier in the literal. However they can also be any expression if wrapped with `[` and `]`.
 
 ```squirrel
-
    table t = { key1 = 1, key2 = "2" }
    table t2 = {
     randomValue = getSomethingRandom()
@@ -47,7 +45,6 @@ Any value of key of the table will therefore be `var` if retrieved.
 Complex tables are tables that have their content types defined. It is necessary to both define the key and value types.
 
 ```squirrel
-
    table<string, int> numbers = {
     one = 1,
     two = 2,

--- a/docs/Modding/squirrel/types/typedefs.md
+++ b/docs/Modding/squirrel/types/typedefs.md
@@ -4,7 +4,6 @@ With typedefs you can create type aliases for types.
 Typedefs can be global as well.
 
 ```squirrel
-
   typedef alias var
   global typedef SomeCallback void functionref(int)
 ```

--- a/docs/Modding/squirrel/types/var.md
+++ b/docs/Modding/squirrel/types/var.md
@@ -3,7 +3,6 @@
 `var` stands for a variable of any type. Any **primitive** can be `var`, however complex types can never be `var`.
 
 ```squirrel
-
   // var can be just about anything.
   var v = 1
   v = "string"

--- a/docs/Modding/squirrel/types/vectors.md
+++ b/docs/Modding/squirrel/types/vectors.md
@@ -11,7 +11,6 @@ Vectors store 3 float values that can be accessed with the `x`, `y` and `z` keys
 A vector literal is a comma seperated list of expressions that evaluate to either a **float** or **integer** delimited by `<` and `>` brackets.
 
 ```squirrel
-
    vector v = < 1, 2.5, 3 >
    v.y = 2
    printt( v.x, v.y, v.z ) // 1 2 3


### PR DESCRIPTION
Most codeblocks had an extra newline at the beginning which was a byproduct of keeping the diff small in #2