### PR TITLE
Remove link to private repo from tools page

### DIFF
--- a/docs/Modding/guides/tools/tools.md
+++ b/docs/Modding/guides/tools/tools.md
@@ -55,7 +55,6 @@
 - [GIF splitter](https://ezgif.com/split)
 - [Rad Tools Bik](http://www.radgametools.com/bnkdown.htm) (needs [Quicktime 7.6](https://support.apple.com/downloads/quicktime))
 - [TexFactory easy DDS conversion](https://otherbenji.gitlab.io/TexFactory/)
-- [Substance Painter to TF2](https://github.com/EM4Volts/tf-2_substance_maker)
 
 - [Tacent View](https://github.com/bluescan/tacentview) - DDS viewer.
 


### PR DESCRIPTION
The repo it links to (https://github.com/EM4Volts/tf-2_substance_maker) was set to private while a better version is being worked on.

There's not really a point in linking to a page that cannot be accessed anyway, so it should be fine to remove for now so that we can get the dead link checker (#6) added until the new version is out ^^