### PR TITLE
Fix link to Respawn Squirrel vscode extension

### DIFF
--- a/docs/Modding/squirrel/index.md
+++ b/docs/Modding/squirrel/index.md
@@ -31,7 +31,7 @@ the top 2. Navigate through the tabs to find what you want to change 3. Click it
 
 RespawnSquirrel has been added to the vscode marketplace, you can download it here:
 
-https://marketplace.visualstudio.com/items?itemName=FrothyWi-Fi.rspn-squirrel
+https://marketplace.visualstudio.com/items?itemName=Sandwhiched.rspn-squirrel
 
 Otherwise you can simply search "Respawn Squirrel" in the extensions tab
 


### PR DESCRIPTION
The publisher of the extension renamed themselves, resulting in a broken link.

See also https://github.com/R2Northstar/ModdingDocs/pull/250 for context.