### PR TITLE
Fix broken internal wiki links

### DIFF
--- a/docs/Wiki/development/README.md
+++ b/docs/Wiki/development/README.md
@@ -13,5 +13,5 @@ Check the subpages on the sidebar for various aspects of Northstar development.
 Check the following page for information about different code repositories Northstar uses
 
 {% content-ref url="repositories/" %}
-[repositories](repositories/)
+[repositories](repositories/README.md)
 {% endcontent-ref %}

--- a/docs/Wiki/hosting-a-server-with-northstar/dedicated-server/hosting-on-linux.md
+++ b/docs/Wiki/hosting-a-server-with-northstar/dedicated-server/hosting-on-linux.md
@@ -90,7 +90,7 @@ services:
     restart: always
 ```
 
-A list of all the CONVARs are [here](../../hosting-a-server-with-northstar/dedicated-server#convars)
+A list of all the CONVARs are [here](../../hosting-a-server-with-northstar/dedicated-server/README.md#convars)
 
 A more complex docker-compose example for hosting a server can be found [here](https://github.com/pg9182/northstar-dedicated#container), along with some extra information.
 

--- a/docs/Wiki/installing-northstar/basic-setup.md
+++ b/docs/Wiki/installing-northstar/basic-setup.md
@@ -5,7 +5,7 @@
 Head over to the installer page and pick one of the existing installers. All of these take care of both installing and updating Northstar.
 
 {% content-ref url="northstar-installers" %}
-[northstar-installers](northstar-installers)
+[northstar-installers](northstar-installers/README.md)
 {% endcontent-ref %}
 
 ## Manual installation

--- a/docs/Wiki/steamdeck-and-linux/installing-on-steamdeck-and-linux.md
+++ b/docs/Wiki/steamdeck-and-linux/installing-on-steamdeck-and-linux.md
@@ -22,7 +22,7 @@ On Steam Deck, complete the following in desktop mode. You may return to game mo
    4. Launch the game and allow the install to completely finish.
    5. Set Titanfall 2 to launch with a more current version of Proton, NorthstarProton, or Proton GE.
    6. If Titanfall 2 still fails to launch, delete the prefix again and try installing with the other version of Proton.
-2. Install the latest version of Northstar using [FlightCore](../installing-northstar/northstar-installers#geckoeidechse-flightcore), [Viper](../installing-northstar/northstar-installers#0negal-viper), or do it manually
+2. Install the latest version of Northstar using [FlightCore](../installing-northstar/northstar-installers/README.md#geckoeidechse-flightcore), [Viper](../installing-northstar/northstar-installers/README.md#0negal-viper), or do it manually
    1. For manual install download the latest version of Northstar from the [releases](https://github.com/R2Northstar/Northstar/releases) page
    2. Then extract all contents of the file to your Titanfall 2 folder ( Right click _Titanfall 2_ > Open _Properties_ > Click _Local Files_ > Click _Browse_ )
 3. Install NorthstarProton or a current version of Proton GE.


### PR DESCRIPTION
For README.md files, GitBook allowed for just linking the path that the file was at. MkDocs does not allow that so the links need to be updated.