### PR TITLE
Re-add missing headers

### DIFF
--- a/docs/Wiki/hosting-a-server-with-northstar/server-settings/file-names.md
+++ b/docs/Wiki/hosting-a-server-with-northstar/server-settings/file-names.md
@@ -1,3 +1,7 @@
+# File names
+
+## Gamemodes
+
 ### Vanilla
 
 | Playlist | Title |


### PR DESCRIPTION
Adds the missing headers back to the file names page that got lost in https://github.com/R2Northstar/NorthstarWiki/pull/218