### PR TITLE
Build in CI with strict mode

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,4 +18,4 @@ jobs:
         run: |
           python3 -m pip install -U poetry
           python3 -m poetry install
-          python3 -m poetry run mkdocs build
+          python3 -m poetry run mkdocs build --strict


### PR DESCRIPTION
Build in CI with strict mode to ensure that CI fails if there are any warnings. This is done to catch issues in PRs before merging them.