### PR TITLE
Convert link embeds from GitBook syntax to MkDocs syntax

### DIFF
--- a/docs/Wiki/README.md
+++ b/docs/Wiki/README.md
@@ -12,7 +12,9 @@ cover: images/northstarbanner.png
 
 Get the newest Northstar release here:
 
-{% embed url="https://github.com/R2Northstar/Northstar/releases" %}
+```embed
+url: https://github.com/R2Northstar/Northstar/releases
+```
 
 Install instructions can be found here:
 
@@ -24,13 +26,18 @@ Install instructions can be found here:
 
 For modding guides, documentation on Northstar API features and documentation on Respawn Squirrel look at:
 
-{% embed url="https://docs.northstar.tf/Modding/" %}
+```embed
+url: https://docs.northstar.tf/Modding/
+```
 
 ## Contact and contributing
 
 **Please remember:** You should expect to encounter bugs and crashes with Northstar.\
 If you need help troubleshooting, setting up or modifying Northstar try talking to the community on our Discord server:
-{% embed url="https://northstar.tf/discord" %}
+
+```embed
+url: https://northstar.tf/discord
+```
 
 Before creating issues or contributing changes to the source code please read:
 
@@ -40,4 +47,6 @@ Before creating issues or contributing changes to the source code please read:
 
 All the source code related to Northstar can be found here:
 
-{% embed url="https://northstar.tf" %}
+```embed
+url: https://northstar.tf
+```

--- a/docs/Wiki/development/contributing-code-to-northstar.md
+++ b/docs/Wiki/development/contributing-code-to-northstar.md
@@ -21,7 +21,9 @@ For a pull request to be merged, it has to be reviewed first. In order to make t
 
 An example of a well-formatted PR description:
 
-{% embed url="https://github.com/R2Northstar/NorthstarMods/pull/392" %}
+```embed
+url: https://github.com/R2Northstar/NorthstarMods/pull/392
+```
 
 To get the cropped GIFs of a screenrecording:
 

--- a/docs/Wiki/development/repositories/northstarlauncher.md
+++ b/docs/Wiki/development/repositories/northstarlauncher.md
@@ -4,4 +4,6 @@
 
 Build instructions for the launcher can be found here:
 
-{% embed url="https://github.com/R2Northstar/NorthstarLauncher/blob/main/BUILD.md" %}
+```embed
+url: https://github.com/R2Northstar/NorthstarLauncher/blob/main/BUILD.md
+```

--- a/docs/Wiki/development/testing.md
+++ b/docs/Wiki/development/testing.md
@@ -37,7 +37,9 @@ You can use FlightCore to essentially 1-click install any pull request to [North
 
 The tool is still being improved upon but already more than usable. Check its README for instructions:
 
-{% embed url="https://github.com/R2NorthstarTools/FlightCore/blob/main/docs/DEV-TOOLS.md" %}
+```embed
+url: https://github.com/R2NorthstarTools/FlightCore/blob/main/docs/DEV-TOOLS.md
+```
 
 
 ### Manually

--- a/docs/Wiki/installing-northstar/northstar-installers/README.md
+++ b/docs/Wiki/installing-northstar/northstar-installers/README.md
@@ -33,7 +33,9 @@ Supports Windows and Linux.
 
 Download and source code:
 
-{% embed url="https://github.com/R2NorthstarTools/FlightCore" %}
+```embed
+url: https://github.com/R2NorthstarTools/FlightCore
+```
 
 ## **ebkr:** r2modman
 
@@ -44,20 +46,28 @@ Supports Windows and Linux.
 
 Download from (select _"Manual Download"_):
 
-{% embed url="https://northstar.thunderstore.io/package/ebkr/r2modman/" %}
+```embed
+url: https://northstar.thunderstore.io/package/ebkr/r2modman/
+```
 
 Source code:
 
-{% embed url="https://github.com/ebkr/r2modmanPlus" %}
+```embed
+url: https://github.com/ebkr/r2modmanPlus
+```
 
 Wiki and documentation:
 
-{% embed url="https://github.com/ebkr/r2modmanPlus/wiki/" %}
+```embed
+url: https://github.com/ebkr/r2modmanPlus/wiki/
+```
 
 There's also an alternative version of r2mm called _Thunderstore Mod Manager_ TMM, which can be downloaded from here:\
 (Contains ads to support the development of Thunderstore)
 
-{% embed url="https://www.overwolf.com/app/Thunderstore-Thunderstore_Mod_Manager" %}
+```embed
+url: https://www.overwolf.com/app/Thunderstore-Thunderstore_Mod_Manager
+```
 
 ## **0neGal:** Viper
 
@@ -68,7 +78,9 @@ Supports Windows and Linux.
 
 Download and source code:
 
-{% embed url="https://github.com/0neGal/viper" %}
+```embed
+url: https://github.com/0neGal/viper
+```
 
 {% embed url="https://www.youtube.com/watch?v=Aes7V5YOSNY" %}
 
@@ -80,10 +92,14 @@ Easy to use and extensive Northstar installer and mod-manager. Supports installi
 
 Download and source code:
 
-{% embed url="https://github.com/BigSpice/VTOL" %}
+```embed
+url: https://github.com/BigSpice/VTOL
+```
 
 ## **AnActualEmerald:** Papa
 
 Command-line only mod manager and Northstar installer written in Rust. Available for Linux as `.deb` and `.msi` Windows installer. Or build from source. Can install, uninstall, and update mods from Thunderstore.
 
-{% embed url="https://github.com/AnActualEmerald/papa" %}
+```embed
+url: https://github.com/AnActualEmerald/papa
+```


### PR DESCRIPTION
Convert link embeds from GitBook syntax to MkDocs syntax excluding YouTube videos which will be handled separately.