### PR TITLE
Rewrite sections containing GitBook styled internal links

### DIFF
--- a/docs/Wiki/README.md
+++ b/docs/Wiki/README.md
@@ -16,11 +16,7 @@ Get the newest Northstar release here:
 url: https://github.com/R2Northstar/Northstar/releases
 ```
 
-Install instructions can be found here:
-
-{% content-ref url="installing-northstar/basic-setup.md" %}
-[basic-setup.md](installing-northstar/basic-setup.md)
-{% endcontent-ref %}
+Install instructions can be found [on this page here](installing-northstar/basic-setup.md)
 
 ## Modding instructions
 
@@ -39,11 +35,7 @@ If you need help troubleshooting, setting up or modifying Northstar try talking 
 url: https://northstar.tf/discord
 ```
 
-Before creating issues or contributing changes to the source code please read:
-
-{% content-ref url="contributing.md" %}
-[contributing.md](contributing.md)
-{% endcontent-ref %}
+Before creating issues or contributing changes to the source code please read [the contributing page](contributing.md)
 
 All the source code related to Northstar can be found here:
 

--- a/docs/Wiki/development/README.md
+++ b/docs/Wiki/development/README.md
@@ -10,8 +10,4 @@ Check the subpages on the sidebar for various aspects of Northstar development.
 
 ## Repositories
 
-Check the following page for information about different code repositories Northstar uses
-
-{% content-ref url="repositories/" %}
-[repositories](repositories/README.md)
-{% endcontent-ref %}
+Check the [repositories page](repositories/README.md) for information about different code repositories Northstar uses

--- a/docs/Wiki/development/reviewing.md
+++ b/docs/Wiki/development/reviewing.md
@@ -35,11 +35,7 @@ Note that this will **NOT** post your comment immediately! Add any remaining com
 
 #### Testing
 
-For testing a PR, refer to the following page
-
-{% content-ref url="../testing.md" %}
-[testing.md](./testing.md)
-{% endcontent-ref %}
+For testing a PR, refer to [the testing page](./testing.md)
 
 The TL;DR is to test the aspect that has been changed.
 

--- a/docs/Wiki/faq.md
+++ b/docs/Wiki/faq.md
@@ -40,17 +40,7 @@ A: AI does work! Custom maps however will take time. Possibly a lot of time, don
 
 A: Due to the way Northstar works, you sadly cannot just create a private match and invite a friend via Steam/Origin. Instead you'll have to host a server.
 
-Check the prerequisites:
-
-{% content-ref url="hosting-a-server-with-northstar/getting-started.md" %}
-[getting-started.md](hosting-a-server-with-northstar/getting-started.md)
-{% endcontent-ref %}
-
-and instructions to host a _listen server_:
-
-{% content-ref url="hosting-a-server-with-northstar/basic-listen-server.md" %}
-[basic-listen-server.md](hosting-a-server-with-northstar/basic-listen-server.md)
-{% endcontent-ref %}
+Check the [prerequisites](hosting-a-server-with-northstar/getting-started.md) and [instructions to host a _listen server_](hosting-a-server-with-northstar/basic-listen-server.md):
 
 ### Q: Can I use Northstar to play the campaign? <a href="#faq-campaign" id="faq-campaign"></a>
 

--- a/docs/Wiki/installing-northstar/basic-setup.md
+++ b/docs/Wiki/installing-northstar/basic-setup.md
@@ -2,27 +2,15 @@
 
 ## Installing Northstar using an installer (recommended):
 
-Head over to the installer page and pick one of the existing installers. All of these take care of both installing and updating Northstar.
-
-{% content-ref url="northstar-installers" %}
-[northstar-installers](northstar-installers/README.md)
-{% endcontent-ref %}
+Head over to [the installer page](northstar-installers/README.md) and pick one of the existing installers. All of these take care of both installing and updating Northstar.
 
 ## Manual installation
 
-If you prefer to avoid any additional installers and know what you're doing, check out the guide for manual installation:
-
-{% content-ref url="manual-installation.md" %}
-[manual-installation.md](manual-installation.md)
-{% endcontent-ref %}
+If you prefer to avoid any additional installers and know what you're doing, check out [the guide for manual installation](manual-installation.md)
 
 ## Troubleshooting
 
-Should you notice any issues/warnings/errors while running Northstar, check the troubleshooting page.
-
-{% content-ref url="troubleshooting.md" %}
-[troubleshooting.md](troubleshooting.md)
-{% endcontent-ref %}
+Should you notice any issues/warnings/errors while running Northstar, check [the troubleshooting page](troubleshooting.md).
 
 ## Additional Stuff
 

--- a/docs/Wiki/installing-northstar/manual-installation.md
+++ b/docs/Wiki/installing-northstar/manual-installation.md
@@ -25,11 +25,7 @@ Firstly, note that the Northstar client is only available on PC and requires you
 5. From the multiplayer menu, you can use the server browser to select and join any of the public community hosted servers.\
    ![Server Browser](../images/lobbyserverbrowser.png)
 
-Should you notice any issues/warnings/errors while running Northstar, check the troubleshooting page.
-
-{% content-ref url="troubleshooting.md" %}
-[troubleshooting.md](troubleshooting.md)
-{% endcontent-ref %}
+Should you notice any issues/warnings/errors while running Northstar, check [the troubleshooting page](troubleshooting.md).
 
 ## Updating Northstar
 


### PR DESCRIPTION
Rewrite sections containing GitBook styled internal links as there's no MkDocs replacement for it. Instead just reformat them to standard internal links and integrate them in the existing text.