### PR TITLE
Change all links from old GitBook to internal links

### DIFF
--- a/docs/Modding/guides/gettingstarted.md
+++ b/docs/Modding/guides/gettingstarted.md
@@ -195,8 +195,7 @@ SetUIVar( level, "gameStartTime", Time() + GetConVarFloat( "ns_private_match_cou
 
 !!! note
 
-    All `Northstar.CustomServers` ConVars are listed here:
-    https://r2northstar.gitbook.io/r2northstar-wiki/hosting-a-server-with-northstar/basic-listen-server
+    All `Northstar.CustomServers` ConVars are listed [on this page](../../Wiki/hosting-a-server-with-northstar/basic-listen-server.md)
 
 #### Flags
 

--- a/docs/Wiki/faq.md
+++ b/docs/Wiki/faq.md
@@ -61,7 +61,7 @@ A: Add `+net_usesocketsforloopback 1` in your `ns_startup_args.txt` and `ns_star
 ### Q: What's with the "r2" part in the name of some of the Northstar things? <a href="#faq-r2" id="faq-r2"></a>
 
 `r2` refers to the internal development name of Titanfall 2 given to it by Respawn. Titanfall 1 for example is `r1`, Apex Legends is `r5`, etc.\
-The reason this wiki for example is called `r2northstar.gitbook.io` is due to the fact that "_Northstar_" is a rather common name and as such often already reserved by other organisations and people. "_R2Northstar_" is both uncommon and therefore still available and ties "_Northstar_" with Titanfall 2, due to the `r2` part of the name.
+The reason the GitHub organisation for example (where Northstar's code is hosted) is called [`R2Northstar`](https://github.com/R2Northstar/) is due to the fact that "_Northstar_" is a rather common name and as such often already reserved by other organisations and people. "_R2Northstar_" is both uncommon and therefore still available and ties "_Northstar_" with Titanfall 2, due to the `r2` part of the name.
 
 ### Q: Can I use a pirated/cracked copy Titanfall 2 to run Northstar? <a href="#faq-piracy" id="faq-piracy"></a>
 

--- a/docs/Wiki/hosting-a-server-with-northstar/dedicated-server/hosting-on-linux.md
+++ b/docs/Wiki/hosting-a-server-with-northstar/dedicated-server/hosting-on-linux.md
@@ -106,7 +106,7 @@ docker-compose up
 
 Your server should be up and running now. Check the in-game server browser or the [online server list](https://northstar.tf/servers) to see if it's online.
 
-Should your server not show up or should you encounter any other issues, check the [server troubleshooting section](https://r2northstar.gitbook.io/r2northstar-wiki/hosting-a-server-with-northstar/troubleshooting) of the wiki.
+Should your server not show up or should you encounter any other issues, check the [server troubleshooting section](../../hosting-a-server-with-northstar/troubleshooting.md) of the wiki.
 
 ## Without using Docker
 

--- a/docs/Wiki/hosting-a-server-with-northstar/troubleshooting.md
+++ b/docs/Wiki/hosting-a-server-with-northstar/troubleshooting.md
@@ -42,7 +42,7 @@ If your port can be accessed from your local IP but not from your public IP, the
 
 **CGNAT**
 
-See [CGNAT](https://r2northstar.gitbook.io/r2northstar-wiki/hosting-a-server-with-northstar/getting-started#cgnat)
+See [CGNAT](getting-started.md#cgnat)
 
 ### If server is not reachable using external IP nor using internal IP
 

--- a/docs/Wiki/other/helping.md
+++ b/docs/Wiki/other/helping.md
@@ -21,7 +21,7 @@ Additionally, please don't be afraid to ask for help. The entirety of `#voluntee
 In the Northstar Discord server, a massively used device to help end users is the tickets bot. A lot of the common issues and questions that come up have tags for them on the Discord server.
 
 Tags are bits of information that you can easily access by using a slash command.
-We use them mostly for common questions (such as the tag explaining how you can spawn the double barrel shotgun and that you can't spawn it in most servers), and for linking directly to specific pages on the wiki (such as the section about [Intel gen 10+ cpus](https://r2northstar.gitbook.io/r2northstar-wiki/installing-northstar/troubleshooting#intel)).
+We use them mostly for common questions (such as the tag explaining how you can spawn the double barrel shotgun and that you can't spawn it in most servers), and for linking directly to specific pages on the wiki (such as the section about [Intel gen 10+ cpus](../installing-northstar/troubleshooting.md#intel)).
 
 The tag command for the tickets bot is `/tag`, and you can either type `/tag id:{TAG ID HERE}` or let the bot autofill the tag for you after typing `/tag` and selecting the tag id from the list (make sure you select the ticket bot, and not Dyno!).
 Note, you can't reply to a user while using a slash command, so try to reply to the bot's message after sending the tag command while pinging the person it's directed at and informing them that they should follow the provided solution.

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,5 +2,5 @@
 
 Here you can find all the documentation for the Titanfall2 mod [Northstar](https://northstar.tf)
 
-- For using Northstar, [check our wiki](https://r2northstar.gitbook.io/)
+- For using Northstar, [check our wiki](Wiki/README.md)
 - For modding with Northstar, check the [modding docs](Modding/index.md)


### PR DESCRIPTION
Change all links from `r2northstar.gitbook.io` to internal links in the docs and adjust text accordingly.

As we transferred content from the old GitBook Wiki into the NorthstarDocs (this repo).