### PR TITLE
Change mentions of the Spectre bot to Reaper

### DIFF
--- a/docs/Wiki/other/helping.md
+++ b/docs/Wiki/other/helping.md
@@ -86,7 +86,7 @@ The bot also provides an online log of the entire ticket connected to the embed 
 A Discord bot created by birb and rewritten by H0L0 which allows you to run commands like `.status` and see how many people are currently online on Northstar, as  well as commands such as `.search region aus` (which would search for Northstar servers with the region set to Australia).
 You can check the [GitHub repo](https://github.com/hummusbird/northstar-bot) for more info on Northstar Servers.
 
-### Spectre
+### Reaper
 
-A Discord bot created by Cyn with help from multiple people designed to automatically reply to specific errors messages, screenshots of error messages, and some more quality of life features for helpers.
-You can check the [GitHub repo](https://github.com/itscynxx/Spectre) for more info on Spectre.
+A Discord bot originally created by Cyn and forked by Gecko, designed to automatically reply to specific errors messages, screenshots of error messages, and some more quality of life features for helpers.
+You can check the [GitHub repo](https://github.com/R2NorthstarTools/Reaper) for more info on Reaper.


### PR DESCRIPTION
Change mentions of the Spectre bot to Reaper as it has since been forked and renamed.

Closes #95