### PR TITLE
Add explanation on why we can't *actually* disable the crosshair

### DIFF
--- a/docs/Modding/guides/keyvalue/crosshairmodding.md
+++ b/docs/Modding/guides/keyvalue/crosshairmodding.md
@@ -91,7 +91,11 @@ WeaponData
     {
         Crosshair_1
         {
-            "ui"                        "ui/crosshair_sniper_amped" //This means NO crosshair
+            //This means NO crosshair, unless your weapon is amped
+            //Ideally, we would disable it entirely via: "ui"    ""
+            //But the game crashes unfortunately
+
+            "ui"                        "ui/crosshair_sniper_amped"
         }
     }
 }

--- a/docs/Modding/guides/keyvalue/crosshairmodding.md
+++ b/docs/Modding/guides/keyvalue/crosshairmodding.md
@@ -91,11 +91,7 @@ WeaponData
     {
         Crosshair_1
         {
-            //This means NO crosshair, unless your weapon is amped
-            //Ideally, we would disable it entirely via: "ui"    ""
-            //But the game crashes unfortunately
-
-            "ui"                        "ui/crosshair_sniper_amped"
+            "ui"                        "ui/crosshair_sniper_amped" //This means NO crosshair, unless your weapon is amped. Ideally, we would disable it entirely via: "ui"    "" , but the game crashes unfortunately
         }
     }
 }


### PR DESCRIPTION
The current "no crosshair" guide is *technically, sort of* lying since, `ui/crosshair_sniper_amped` actually becomes visible if your weapon is amped. This just adds an explanation on *why* we can't disable it entirely.