### PR TITLE
Define default site description

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,6 @@
 site_name: Northstar Documentation
 site_url: https://docs.northstar.tf/
+site_description: "The official documentation and wiki for Northstar"
 repo_url: https://github.com/R2Northstar/NorthstarDocs
 edit_uri: blob/main/docs/
 theme:


### PR DESCRIPTION
Sets a default description to be shown in embed previews.

Example:
![image](https://github.com/user-attachments/assets/352052c4-3753-486b-96fe-863fa28cd019)

Closes #110
