### PR TITLE
Link to GitHub for source code

### DIFF
--- a/docs/Wiki/README.md
+++ b/docs/Wiki/README.md
@@ -40,5 +40,5 @@ Before creating issues or contributing changes to the source code please read [t
 All the source code related to Northstar can be found here:
 
 ```embed
-url: https://northstar.tf
+url: https://northstar.tf/github
 ```


### PR DESCRIPTION
The link to the source code was still pointing directly to the website which is a leftover from when we didn't have a website yet.