### PR TITLE
Enable rendering footnotes

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -76,6 +76,7 @@ markdown_extensions:
   - attr_list
   - def_list
   - md_in_html
+  - footnotes
   - pymdownx.betterem
   - pymdownx.caret
   - pymdownx.mark


### PR DESCRIPTION
https://squidfunk.github.io/mkdocs-material/reference/footnotes/

Adds support for rendering markdown footnotes like

> Hi from text[^1]
> [^1]: Hi from footnote

The syntax for which is:
```
Hi from text[^1]
[^1]: Hi from footnote
```