### PR TITLE
Run linkcheck periodically

### DIFF
--- a/.github/workflows/linkcheck.yml
+++ b/.github/workflows/linkcheck.yml
@@ -1,5 +1,9 @@
 name: Linkcheck
-on: [push, pull_request]
+on: 
+  push:
+  pull_request:
+  schedule:
+    - cron: '0 0 * * 0' # Once a week
 
 jobs:
   markdown-link-check:

--- a/.github/workflows/linkcheck.yml
+++ b/.github/workflows/linkcheck.yml
@@ -1,5 +1,5 @@
 name: Linkcheck
-on: 
+on:
   push:
   pull_request:
   schedule:


### PR DESCRIPTION
Adds entry to config to run linkcheck once a week to catch any links that may have broken in the meantime.
