### PR TITLE
Remove hardcoded background colour

### DIFF
--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -71,7 +71,6 @@
     --md-code-hl-comment-color: var(--catpuccin-overlay2);
     --md-code-hl-generic-color: var(--catpuccin-teal);
     --md-code-hl-variable-color: var(--catpuccin-yellow);
-    --md-code-bg-color: var(--catpuccin-surface0);
 }
 
 .md-typeset code {


### PR DESCRIPTION
Removes the hardcoded styling that forces the code sections background to be dark even in light mode.

Closes #61
