### PR TITLE
build: Update CI link checking action

### DIFF
--- a/.github/.markdownlinkcheck.json
+++ b/.github/.markdownlinkcheck.json
@@ -35,6 +35,15 @@
         },
         {
             "pattern": "https://www.wunderboy.org/valve-hl2source-sdk-tools/#vtf_shell"
+        },
+        {
+            "pattern": "https://www.blender.org/"
+        },
+        {
+            "pattern": "*#*"
+        },
+        {
+            "pattern": "/_static/"
         }
     ]
 }

--- a/.github/.markdownlinkcheck.json
+++ b/.github/.markdownlinkcheck.json
@@ -40,6 +40,9 @@
             "pattern": "https://www.blender.org/"
         },
         {
+            "pattern": "#*"
+        },
+        {
             "pattern": "/_static/"
         }
     ]

--- a/.github/.markdownlinkcheck.json
+++ b/.github/.markdownlinkcheck.json
@@ -40,9 +40,6 @@
             "pattern": "https://www.blender.org/"
         },
         {
-            "pattern": "*#*"
-        },
-        {
             "pattern": "/_static/"
         }
     ]

--- a/.github/workflows/linkcheck.yml
+++ b/.github/workflows/linkcheck.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: md-linkcheck
-        uses: gaurav-nelson/github-action-markdown-link-check@v1
+        uses: tcort/github-action-markdown-link-check@v1
         with:
           use-quiet-mode: 'yes'
           config-file: '.github/.markdownlinkcheck.json'


### PR DESCRIPTION
Since the one previously used
(gaurav-nelson/github-action-markdown-link-check) is deprecated, we switch to the tcort maintained fork of the action.
