### PR TITLE
Replace NorthstarProton with GE-Proton in Linux section

### DIFF
--- a/docs/Wiki/steamdeck-and-linux/installing-on-steamdeck-and-linux.md
+++ b/docs/Wiki/steamdeck-and-linux/installing-on-steamdeck-and-linux.md
@@ -3,10 +3,6 @@
 ## Steam & Steam Deck (NorthstarProton)
 
 !!! warning
-    EA App currently displays a blank screen when using NorthstarProton, however Northstar will still launch assuming you have logged in to EA App at least once.
-
-
-!!! warning
     NorthstarProton has some problems and may stop working at any point, if this happens you can try [deleting the compatibility directory](linux-troubleshooting.md#northstar-not-launching-with-steam) or visit the Northstar Discord for help.
 
 

--- a/docs/Wiki/steamdeck-and-linux/installing-on-steamdeck-and-linux.md
+++ b/docs/Wiki/steamdeck-and-linux/installing-on-steamdeck-and-linux.md
@@ -1,9 +1,9 @@
 # Installing on SteamDeck and Linux
 
-## Steam & Steam Deck (NorthstarProton)
+## Steam & Steam Deck
 
 !!! warning
-    NorthstarProton has some problems and may stop working at any point, if this happens you can try [deleting the compatibility directory](linux-troubleshooting.md#northstar-not-launching-with-steam) or visit the Northstar Discord for help.
+    Due to instabilities with the EA App in wine it may corrupt your install, if you are having trouble launching the game try [deleting the compatibility directory](linux-troubleshooting.md#northstar-not-launching-with-steam) or visit the Northstar Discord for help.
 
 
 On Steam Deck, complete the following in desktop mode. You may return to game mode once completed _(A mouse + keyboard plugged into the Deck are recommended for easier navigation of menus)_
@@ -14,28 +14,22 @@ On Steam Deck, complete the following in desktop mode. You may return to game mo
     2. Delete the folder named `1237970`
     3. Set Titanfall 2 to launch with `Proton 6.3-8` or `Proton 7.0-6` in the _Properties_ -> _Compatibility_ section.
     4. Launch the game and allow the install to completely finish.
-    5. Set Titanfall 2 to launch with a more current version of Proton, NorthstarProton, or Proton GE.
+    5. Set Titanfall 2 to launch with a more current version of Proton GE.
     6. If Titanfall 2 still fails to launch, delete the prefix again and try installing with the other version of Proton.
  2. Install the latest version of Northstar using [FlightCore](../installing-northstar/northstar-installers/README.md#geckoeidechse-flightcore), [Viper](../installing-northstar/northstar-installers/README.md#0negal-viper), or do it manually
     1. For manual install download the latest version of Northstar from the [releases](https://github.com/R2Northstar/Northstar/releases) page
     2. Then extract all contents of the file to your Titanfall 2 folder ( Right click _Titanfall 2_ > Open _Properties_ > Click _Local Files_ > Click _Browse_ )
- 3. Install NorthstarProton or a current version of Proton GE.<br>
-    In some user cases, NorthstarProton may not work. You may instead try Proton GE, which is also available through the following methods.
-    1. **Protonup-QT**: Click _About_, then tick the box to enable _advanced mode_. You should be able to select and install NorthstarProton from the _Add version_ menu.
-    2. **ProtonPlus**: NorthstarProton can also be installed via ProtonPlus.
-    3. **Manual**: Download the latest release of [NorthstarProton](https://github.com/cyrv6737/NorthstarProton/releases/), extract it, and place the `Proton X.Y-Z/` folder in one of the following directories (you may need to create `compatibilitytools.d/`):
+ 3. Install a current version of Proton GE.<br>
+    1. **Protonup-QT**: Select GE-Proton in the _Add version_ menu and press _Install_.
+    2. **ProtonPlus**: GE-Proton can also be installed via ProtonPlus.
+    3. **Manual**: Download the latest release of [GE-Proton](https://github.com/GloriousEggroll/proton-ge-custom/releases/), extract it, and place the `Proton X.Y-Z/` folder in one of the following directories (you may need to create `compatibilitytools.d/`):
          * **Steam (Native Package) & Steam Deck:** `~/.local/share/Steam/compatibilitytools.d/`
          * **Steam (Flatpak):** `~/.var/app/com.valvesoftware.Steam/data/Steam/compatibilitytools.d/`
- 4. Restart Steam. Head to `Properties -> Compatibility` under Titanfall2. Check `Force the use of a specific Steam Play compatibility tool` checkbox, then set the Steam Play compatibility tool to NorthstarProton.
+ 4. Restart Steam. Head to `Properties -> Compatibility` under Titanfall2. Check `Force the use of a specific Steam Play compatibility tool` checkbox, then set the Steam Play compatibility tool to GE-Proton.
  5. Add `%command% -northstar` as a [launch option](../installing-northstar/troubleshooting.md#launch-opts) to Titanfall2
  6. Launch Titanfall2, it should now launch Northstar
 
 Note that removing the `%command% -northstar` will cause Steam to launch the vanilla game again.
-
-!!! info
-    This guide assumes you're *up to date with NorthstarProton*, as the method used to launch Northstar changed in NorthstarProton-8.1-1 which was released on 2023-02-22.\
-    If you're using an older version of NorthstarProton, replace the information about launch options with a text file called `run_northstar.txt` in your Titanfall2 directory. This text file should have a single character `1` inside.
-
 
 ## Lutris (Wine)
 
@@ -55,7 +49,7 @@ LatencyFleX is a Linux-only input latency reduction alternative to Nvidia Reflex
 
 LatencyFleX's Vulkan layer can be installed with your package manager on supported distributions. On Arch it's available in [AUR](https://aur.archlinux.org/packages/latencyflex-git), and on Fedora/openSUSE Tumbleweed it can be acquired from [Copr](https://copr.fedorainfracloud.org/coprs/kylegospo/LatencyFleX/).
 
-If you're using another distro you will need to install LatencyFleX manually. A full install guide and current releases [can be found on their GitHub](https://github.com/ishitatsuyuki/LatencyFleX). Northstar only requires the [Vulkan layer](https://github.com/ishitatsuyuki/LatencyFleX#latencyflex-vulkan-layer-essential) and [Wine extensions](https://github.com/ishitatsuyuki/LatencyFleX#latencyflex-wine-extensions-required-for-proton-reflex-integration) steps to be completed. **If you are using NorthstarProton, the Wine extensions are automatically installed and only the Vulkan layer is required.**
+If you're using another distro you will need to install LatencyFleX manually. A full install guide and current releases [can be found on their GitHub](https://github.com/ishitatsuyuki/LatencyFleX). Northstar only requires the [Vulkan layer](https://github.com/ishitatsuyuki/LatencyFleX#latencyflex-vulkan-layer-essential) and [Wine extensions](https://github.com/ishitatsuyuki/LatencyFleX#latencyflex-wine-extensions-required-for-proton-reflex-integration) steps to be completed.
 
 Once installed, LatencyFleX can be enabled by doing either of the following:
 

--- a/docs/Wiki/steamdeck-and-linux/installing-on-steamdeck-and-linux.md
+++ b/docs/Wiki/steamdeck-and-linux/installing-on-steamdeck-and-linux.md
@@ -6,8 +6,6 @@
     NorthstarProton has some problems and may stop working at any point, if this happens you can try [deleting the compatibility directory](linux-troubleshooting.md#northstar-not-launching-with-steam) or visit the Northstar Discord for help.
 
 
-> **Check your GLIBC version.** NorthstarProton currently only supports version 2.33 and higher. Verify your installed version with `ldd --version`. **Ubuntu 20.04 LTS** and **Debian 11** are known to have outdated GLIBC packages, meaning you will have to experiment with finding a Proton version that works for you, or use Lutris. It is therefore strongly recommended to use an up-to-date Linux distro to be able to make use of NorthstarProton. This check does not need to be completed on Steam Deck or Steam OS.
-
 On Steam Deck, complete the following in desktop mode. You may return to game mode once completed _(A mouse + keyboard plugged into the Deck are recommended for easier navigation of menus)_
 
  1. Make sure you ran the vanilla version of Titanfall2 at least once on Linux!<br>

--- a/docs/Wiki/steamdeck-and-linux/linux-troubleshooting.md
+++ b/docs/Wiki/steamdeck-and-linux/linux-troubleshooting.md
@@ -99,18 +99,6 @@ Proton: extract and put it in `/path/to/steamapps/shadercache/1237970/DXVK_state
 
 Wine: extract and put it next to game's .exe. Also remember to rename it if the .exe has a different name.
 
-### Steam/Steam Deck (dxvk-async)
-
-DXVK-async is automatically installed and enabled if using the NorthstarProton runner.
-
-### Lutris (dxvk-async)
-
-DXVK-[_async_](https://github.com/Sporif/dxvk-async#improvements) can optionally be used on Lutris to prevent stutter during shader compilation by asynchronously compiling and allowing the frame to render with not-yet-compiled shaders simply not drawn.
-
-Download [**dxvk-async**](https://github.com/Sporif/dxvk-async/releases), extract and put it in `~/.local/share/lutris/runtime/dxvk` then type the name of the folder in `▲` -> `Configure` -> `Runner Options` -> `DXVK version`, to enable add `DXVK_ASYNC 1` to `System Options` -> `Environment variables`
-
-_DXVK-async can also be installed for Lutris with_ [_ProtonUp-Qt_](https://davidotek.github.io/protonup-qt/)
-
 ### Origin Continual File Writing Fix
 
 [_Preventing_](https://github.com/ValveSoftware/Proton/issues/4001#issuecomment-647014231) _Origin from writing certain files_:

--- a/docs/Wiki/steamdeck-and-linux/linux-troubleshooting.md
+++ b/docs/Wiki/steamdeck-and-linux/linux-troubleshooting.md
@@ -7,7 +7,7 @@ If you're encountering issues with Northstar launching on Steam, a very quick fi
 You can do this by going to your Steam directory, going to `steamapps/compatdata`, then look for the folder called `1237970` (the App ID for Titanfall2). This folder contains the data used by Steam in order to make games function using Proton (assuming you're using Proton for said game).
 This folder, however, sometimes has issues with launching Northstar.
 
-It is recommended you close Steam before this. Deleting this folder then attempting to launch Northstar with NorthstarProton again _should_ fix the issue. Steam will generate another `compatdata` folder for Titanfall2 automatically.
+It is recommended you close Steam before this. Deleting this folder then attempting to launch Northstar again _should_ fix the issue. Steam will generate another `compatdata` folder for Titanfall2 automatically.
 
 ## EA App blank window
 
@@ -83,7 +83,7 @@ For more info and proposed fixes, refer to [this issue thread on Github](https:/
 
 ## Game crashes on launch with Cause: Access Violation Data Execution Prevention (DEP) at: 0x00000000
 
-**Steam/Steam Deck:** Ensure your installation matches the latest [install guide](installing-on-steamdeck-and-linux.md#steam-steam-deck-northstarproton).
+**Steam/Steam Deck:** Ensure your installation matches the latest [install guide](installing-on-steamdeck-and-linux.md#steam-steam-deck).
 
 **Lutris**: Ensure your installation matches the latest [install guide](installing-on-steamdeck-and-linux.md#lutris-wine). If that fails, you may optionally try the latest release of [Wine-TKG](https://github.com/Frogging-Family/wine-tkg-git/releases/latest).
 


### PR DESCRIPTION
NorthstarProton has not been maintained in over a year and everyone involved with it has stopped working on it.

GE-Proton provides all the needed functionality to run Northstar without having to fiddle with anything while also being actively maintained.
